### PR TITLE
webpack: include webpack and initial config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ node_modules
 # Typings
 /typings
 /tsd_typings
+
+# Webpack build output
+__build__

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "serve-static": "^1.10.0",
     "tsd": "^0.6.3",
     "typescript": "^1.5.3",
+    "typescript-simple-loader": "^0.3.3",
+    "webpack": "^1.10.5",
     "yargs": "^3.14.0",
     "zone.js": "^0.5.2"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,55 @@
+var fs = require('fs');
+var path = require('path');
+var webpack = require('webpack');
+var sliceArgs = Function.prototype.call.bind(Array.prototype.slice);
+
+// Object containing all node modules 
+// for excluding dependencies in server side builds
+var nodeModules = {};
+fs.readdirSync('node_modules')
+  .filter(function(x) {
+    return ('.bin' !== x);
+  })
+  .forEach(function(mod) {
+    nodeModules[mod] = 'commonjs ' + mod;
+  });
+
+module.exports = {
+  resolve: {
+    extensions: ['', '.ts', '.js']
+  },
+
+  entry: {
+    'server/server': './modules/server/server',
+    'preboot/server': './modules/preboot/server',
+    'preboot/client': './modules/preboot/client',
+    'experimental/experimental': './modules/experimental/experimental'
+  },
+
+  output: {
+    path: root('__build__'),
+    filename: '[name].js',
+  },
+
+  node: {
+    fs: 'empty'
+  },
+
+  externals: nodeModules,
+
+  module: {
+    loaders: [
+      {
+        test: /\.ts$/,
+        loader: 'typescript-simple-loader'
+      }
+    ]
+  }
+
+}
+
+
+function root(args) {
+  args = sliceArgs(arguments, 0);
+  return path.join.apply(path, [__dirname].concat(args));
+}


### PR DESCRIPTION
@gdi2290 Please let me know how to proceed further. 

I want to know about specific entry points of the build. And if the build will be separate for client and server. Is this going in the direction of https://github.com/rackt/react-router where it has a single entry for publishing a library?

So far I got Webpack to build individual modules (as a smoke test) - 
* server/server
* preboot/server
* preboot/client