### PR TITLE
fix(bower): fix install location of bower_components

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
- Specify location for install of bower_components

By default bower installs to `app/bower_components` - this change fixes the location to what appears to be the intended location.