### PR TITLE
fix(helper): backslash escaping (\s\S) in template strings are handled incorrectly

### DIFF
--- a/modules/universal/server/src/helper.ts
+++ b/modules/universal/server/src/helper.ts
@@ -52,7 +52,7 @@ export function selectorRegExpFactory(selector: string): RegExp {
    /<([^\s\>]+)[^>]*>([\s\S]*?)<\/\1>/
   */
 
-  let regExpSelect = `<${ escapeRegExp(selector) }[^>]*>([\s\S]*?)<\/${ escapeRegExp(selector) }>`;
+  let regExpSelect = `<${ escapeRegExp(selector) }[^>]*>([\\s\\S]*?)<\/${ escapeRegExp(selector) }>`;
   return new RegExp(regExpSelect);
 }
 


### PR DESCRIPTION
This fixes a issue with the selector with attrs RegExp and template string (https://github.com/angular/universal/commit/787d98c90dfdb713c1e80a97764c51424ade967b)

Before:
```js
var regExpSelect = "<" + escapeRegExp(selector) + "[^>]*>([sS]*?)</" + escapeRegExp(selector) + ">";
```

After:
```js
var regExpSelect = "<" + escapeRegExp(selector) + "[^>]*>([\\s\\S]*?)</" + escapeRegExp(selector) + ">";
```

See: https://github.com/Microsoft/TypeScript/issues/2803