### PR TITLE
chore: remove bower

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,7 +117,6 @@ var CONFIG = {
       './*_spec.js',
       './angular',
       './.DS_Store',
-      './bower_components',
       './tsd_typings',
       './web_modules',
       './.idea'

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "url": "https://github.com/angular/universal/issues"
   },
   "devDependencies": {
-    "bower": "^1.4.1",
     "brfs": "^1.4.0",
     "browser-sync": "^2.8.2",
     "connect-history-api-fallback": "^1.1.0",


### PR DESCRIPTION
- Remove all bower references

I don't see anymore reference to bower usage, so this strips out the vestiges.