### PR TITLE
fix(server): fix return type

### DIFF
--- a/modules/universal/server/src/router/server_platform_location.ts
+++ b/modules/universal/server/src/router/server_platform_location.ts
@@ -42,7 +42,7 @@ class NodeLocation implements LocationConfig {
   format(obj: NodeLocationConfig): string {
     return nodeUrl.format(obj);
   }
-  assign(parsed: NodeLocationConfig): this {
+  assign(parsed: NodeLocationConfig): NodeLocation {
     this.pathname = parsed.pathname || '';
     this.search = parsed.search || '';
     this.hash = parsed.hash;


### PR DESCRIPTION
- Fix the type, which causes TS to compile improperly

The current release of angular2-universal-preview has this syntax error in `server/src/router/server_platform_location.js`:

```js
var NodeLocation = (function () {
    function NodeLocation(config) {
        this.assign(config);
    }
    Object.defineProperty(NodeLocation.prototype, "origin", {
        get: function () {
            return this.protocol + '//' + this.hostname + ':' + this.port;
        },
        enumerable: true,
        configurable: true
    });
    NodeLocation.prototype.parse = function (url) {
        return nodeUrl.parse(url);
    };
    NodeLocation.prototype.format = function (obj) {
        return nodeUrl.format(obj);
    };
    NodeLocation.prototype.assign = ;
    return NodeLocation;
})();
```

I believe this is due to https://github.com/angular/universal/blob/master/modules/universal/server/src/router/server_platform_location.ts#L45 where the return type is set to `this` instead of `NodeLocation`.