### PR TITLE
feat(render): add renderDocument() and renderDocumentWithPreboot()

### DIFF
--- a/modules/universal/server/src/platform/document.ts
+++ b/modules/universal/server/src/platform/document.ts
@@ -1,0 +1,80 @@
+import { OpaqueToken } from 'angular2/core';
+import { Parser, Serializer, TreeAdapters } from 'parse5';
+import { DOM } from 'angular2/src/platform/dom/dom_adapter';
+
+const parser = new Parser(TreeAdapters.htmlparser2);
+const serializer = new Serializer(TreeAdapters.htmlparser2);
+const treeAdapter = parser.treeAdapter;
+
+function isTag(tagName, node): boolean {
+  return node.type === 'tag' && node.name === tagName;
+}
+
+export function parseDocument(documentHtml: string): Object {
+  const doc = parser.parse(documentHtml);
+  let rootNode, bodyNode, headNode, titleNode;
+
+  for (let i = 0; i < doc.children.length; ++i) {
+    const child = doc.children[i];
+
+    if (isTag('html', child)) {
+      rootNode = child;
+      break;
+    }
+  }
+
+  if (!rootNode) {
+    rootNode = doc;
+  }
+
+  for (let i = 0; i < rootNode.children.length; ++i) {
+    const child = rootNode.children[i];
+
+    if (isTag('head', child)) {
+      headNode = child;
+    }
+
+    if (isTag('body', child)) {
+      bodyNode = child;
+    }
+  }
+
+  if (!headNode) {
+    headNode = treeAdapter.createElement('head', null, []);
+    DOM.appendChild(doc, headNode);
+  }
+
+  if (!bodyNode) {
+    bodyNode = treeAdapter.createElement('body', null, []);
+    DOM.appendChild(doc, headNode);
+  }
+
+  for (let i = 0; i < headNode.children.length; ++i) {
+    if (isTag('title', headNode.children[i])) {
+      titleNode = headNode.children[i];
+      break;
+    }
+  }
+
+  if (!titleNode) {
+    titleNode = treeAdapter.createElement('title', null, []);
+    DOM.appendChild(headNode, titleNode);
+  }
+
+  doc._window = {};
+  doc.head = headNode;
+  doc.body = bodyNode;
+
+  const titleNodeText = titleNode.children[0];
+
+  Object.defineProperty(doc, 'title', {
+    get: () => titleNodeText.data,
+    set: (newTitle) => titleNodeText.data = newTitle
+  });
+
+  return doc;
+}
+
+export function serializeDocument(document: Object): string {
+  return serializer.serialize(document);
+}

--- a/modules/universal/server/src/render.ts
+++ b/modules/universal/server/src/render.ts
@@ -1,11 +1,12 @@
 import {bootstrap} from './platform/node';
+import {parseDocument, serializeDocument} from './platform/document';
+import {DOCUMENT} from 'angular2/platform/common_dom';
 
 import {
   selectorRegExpFactory,
   arrayFlattenTree
 } from './helper';
 import {stringifyElement} from './stringifyElement';
-
 
 import {
   prebootConfigDefault,
@@ -18,9 +19,57 @@ import {isBlank, isPresent} from 'angular2/src/facade/lang';
 
 import {SharedStylesHost} from 'angular2/src/platform/dom/shared_styles_host';
 
-import {NgZone, DirectiveResolver, ComponentRef} from 'angular2/core';
+import {NgZone, DirectiveResolver, ComponentRef, Provider, Type} from 'angular2/core';
 import {Http} from 'angular2/http';
 import {Router} from 'angular2/router';
+
+function addPrebootHtml(html, prebootConfig: any = {}) {
+  if (typeof prebootConfig === 'boolean' && prebootConfig === false) {
+    return html;
+  }
+
+  let config = prebootConfigDefault(prebootConfig);
+  return getBrowserCode(config).then(code => html + createPrebootHTML(code, config));
+}
+
+function waitRouter(appRef: ComponentRef): Promise<ComponentRef> {
+  let injector = appRef.injector;
+  let router = injector.getOptional(Router);
+
+  return Promise.resolve(router && router._currentNavigation)
+    .then(() => new Promise(resolve => setTimeout(() => resolve(appRef))));
+}
+
+export function renderDocument(
+  documentHtml: string,
+  componentType: Type,
+  serverProviders?: any
+): Promise<string> {
+
+  return bootstrap(componentType, [
+    ...serverProviders,
+    new Provider(DOCUMENT, { useValue: parseDocument(documentHtml) })
+  ])
+  .then(waitRouter)
+  .then((appRef: ComponentRef) => {
+    let injector = appRef.injector;
+    let document = injector.get(DOCUMENT);
+
+    return serializeDocument(document);
+  });
+}
+
+export function renderDocumentWithPreboot(
+  documentHtml: string,
+  componentType: Type,
+  serverProviders?: any,
+  prebootConfig: any = {}
+): Promise<string> {
+
+  return renderDocument(documentHtml, componentType, serverProviders)
+    .then(html => addPrebootHtml(html, prebootConfig));
+}
+
 
 export var serverDirectiveResolver = new DirectiveResolver();
 
@@ -62,13 +111,7 @@ export function appRefSyncRender(appRef: any): string {
 
 export function renderToString(AppComponent: any, serverProviders?: any): Promise<string> {
   return bootstrap(AppComponent, serverProviders)
-    .then((appRef: ComponentRef) => {
-      let injector = appRef.injector;
-      let router = injector.getOptional(Router);
-
-      return Promise.resolve(router && router._currentNavigation)
-        .then(() => new Promise(resolve => setTimeout(() => resolve(appRef))));
-    })
+    .then(waitRouter)
     .then((appRef: ComponentRef) => {
       let html = appRefSyncRender(appRef);
       appRef.dispose();
@@ -78,11 +121,5 @@ export function renderToString(AppComponent: any, serverProviders?: any): Promis
 
 
 export function renderToStringWithPreboot(AppComponent: any, serverProviders?: any, prebootConfig: any = {}): Promise<string> {
-  return renderToString(AppComponent, serverProviders)
-    .then((html: string) => {
-      if (typeof prebootConfig === 'boolean' && prebootConfig === false) { return html; }
-      let config = prebootConfigDefault(prebootConfig);
-      return getBrowserCode(config)
-        .then(code => html + createPrebootHTML(code, config));
-    });
+  return renderToString(AppComponent, serverProviders).then(html => addPrebootHtml(html, prebootConfig));
 }


### PR DESCRIPTION
Relates to #238 

1. Because in [this comment](https://github.com/angular/universal/issues/238#issuecomment-177429694) @gdi2290 said that "we need to support both ways of creating the document" I've decided not to change `DOCUMENT` provider. Instead I've implemented `renderDocument()` and `renderDocumentWithPreboot()` functions.

2. `parseDocument` function should be implemented in core angular2 library [here](https://github.com/angular/angular/blob/master/modules/angular2/src/platform/server/parse5_adapter.ts#L557)

3. Parsing the same html on each request is not reasonable. But it can be easily optimized (and it should be).