### PR TITLE
core(universal): update beta.7

### DIFF
--- a/modules/angular2-grunt-prerender/package.json
+++ b/modules/angular2-grunt-prerender/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
   },
   "peerDependencies": {
-    "angular2": "2.0.0-beta.1 - 2.0.0-beta.6",
+    "angular2": "2.0.0-beta.1 - 2.0.0-beta.7",
     "angular2-universal-preview": "*",
     "css": "^2.2.1",
     "es6-shim": "^0.33.3",

--- a/modules/angular2-gulp-prerender/package.json
+++ b/modules/angular2-gulp-prerender/package.json
@@ -32,7 +32,7 @@
     "through2": "^2.0.0"
   },
   "peerDependencies": {
-    "angular2": "2.0.0-beta.1 - 2.0.0-beta.6",
+    "angular2": "2.0.0-beta.1 - 2.0.0-beta.7",
     "angular2-universal-preview": "*",
     "css": "^2.2.1",
     "es6-shim": "^0.33.3",

--- a/modules/angular2-webpack-prerender/package.json
+++ b/modules/angular2-webpack-prerender/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "webpack": "^1.12.12",
-    "angular2": "2.0.0-beta.1 - 2.0.0-beta.6",
+    "angular2": "2.0.0-beta.1 - 2.0.0-beta.7",
     "angular2-universal-preview": "*",
     "css": "^2.2.1",
     "es6-shim": "^0.33.3",

--- a/modules/universal/package.json
+++ b/modules/universal/package.json
@@ -49,7 +49,7 @@
     "preboot": "~1.1.0",
     "angular2-express-engine": "*",
     "rxjs": "~5.0.0-beta.0",
-    "angular2": "2.0.0-beta.1 - 2.0.0-beta.6",
+    "angular2": "2.0.0-beta.1 - 2.0.0-beta.7",
     "es6-shim": "^0.33.3",
     "zone.js": "~0.5.14",
     "css": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "yargs": "^3.14.0"
   },
   "dependencies": {
-    "angular2": "2.0.0-beta.6",
+    "angular2": "2.0.0-beta.7",
     "angular2-express-engine": "file:modules/angular2-express-engine",
     "angular2-universal": "file:modules/universal",
     "angular2-universal-preview": "file:modules/universal",
@@ -111,11 +111,11 @@
     "reflect-metadata": "0.1.2",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.2",
-    "rxjs": "5.0.0-beta.0",
-    "systemjs": "^0.19.16",
+    "rxjs": "5.0.0-beta.2",
+    "systemjs": "^0.19.18",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "xhr2": "^0.1.3",
-    "zone.js": "0.5.14"
+    "zone.js": "0.5.15"
   }
 }

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -30,7 +30,7 @@ exports.config = {
     }
   },
   // https://github.com/mllrsohn/gulp-protractor#protractor-webdriver
-  seleniumServerJar: './node_modules/protractor/selenium/selenium-server-standalone-2.48.2.jar',
+  seleniumServerJar: './node_modules/protractor/selenium/selenium-server-standalone-2.51.0.jar',
   //seleniumAddress: 'http://localhost:4444/wd/hub',
 
   onPrepare: function() {


### PR DESCRIPTION
Hi, 

this PR should upgrade it to beta.7 which I'd require to use this lib within my project. I quickly tried to test whether it still works and it seems fine. Also, the `npm test` run succeeds.

_Also wanted to run the e2e tests, but for some reason it didn't work.._