### PR TITLE
chore(prereboot): replay 'input' and 'change' events during preboot

### DIFF
--- a/modules/preboot/src/server/presets.ts
+++ b/modules/preboot/src/server/presets.ts
@@ -11,7 +11,7 @@ export default {
     opts.listen.push({
       name: 'selectors',
       eventsBySelector: {
-        'input,textarea': ['keypress', 'keyup', 'keydown']
+        'input,textarea': ['keypress', 'keyup', 'keydown', 'input', 'change']
       }
     });
     opts.listen.push({

--- a/modules/preboot/test/server/presets_spec.ts
+++ b/modules/preboot/test/server/presets_spec.ts
@@ -16,7 +16,7 @@ describe('presets', function () {
                 {
                   name: 'selectors',
                   eventsBySelector: {
-                    'input,textarea': ['keypress', 'keyup', 'keydown']
+                    'input,textarea': ['keypress', 'keyup', 'keydown', 'input', 'change']
                   }
                 },
                 {
@@ -28,10 +28,10 @@ describe('presets', function () {
               ]
             };
             presetFns.keyPress(opts);
-            
+
             console.log(JSON.stringify(opts));
             console.log(JSON.stringify(expected));
-            
+
             expect(opts).toEqual(expected);
         });
     });


### PR DESCRIPTION
closes https://github.com/angular/universal/issues/245