### PR TITLE
feat(NodeXHRImpl): support file:// url fetching

### DIFF
--- a/modules/universal/src/node/platform/node_xhr_impl.ts
+++ b/modules/universal/src/node/platform/node_xhr_impl.ts
@@ -1,5 +1,6 @@
 import * as http from 'http';
 import * as url from 'url';
+import * as fs from 'fs';
 
 import {XHR} from 'angular2/compiler';
 import {PromiseWrapper, PromiseCompleter} from 'angular2/src/facade/promise';
@@ -9,30 +10,40 @@ export class NodeXHRImpl extends XHR {
     const completer: PromiseCompleter<string> = PromiseWrapper.completer();
     const parsedUrl = url.parse(templateUrl);
 
-    http.get(parsedUrl, (res) => {
-      res.setEncoding('utf8');
+    if (parsedUrl.protocol === 'file:') {
+      fs.readFile(parsedUrl.path, (err, data) => {
+        if (err) {
+          return completer.reject(`Failed to load ${templateUrl} with error ${err}`);
+        }
+        completer.resolve(data.toString());
+      });
+    }
+    else {
+      http.get(parsedUrl, (res) => {
+        res.setEncoding('utf8');
 
-      const status = res.statusCode;
+        const status = res.statusCode;
 
-      if (200 <= status && status <= 300) {
-        let data = '';
+        if (200 <= status && status <= 300) {
+          let data = '';
 
-        res.on('data', (chunk) => {
-          data += chunk;
-        });
-        res.on('end', () => {
-          completer.resolve(data);
-        });
+          res.on('data', (chunk) => {
+            data += chunk;
+          });
+          res.on('end', () => {
+            completer.resolve(data);
+          });
 
-      } else {
+        } else {
+          completer.reject(`Failed to load ${templateUrl}`, null);
+        }
+
+        // consume response body
+        res.resume();
+      }).on('error', (e) => {
         completer.reject(`Failed to load ${templateUrl}`, null);
-      }
-
-      // consume response body
-      res.resume();
-    }).on('error', (e) => {
-      completer.reject(`Failed to load ${templateUrl}`, null);
-    });
+      });
+    }
 
     return completer.promise;
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] preboot
- [ ] universal-preview
- [x] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files

Allows the `NodeXHRImpl` to resolve file:// urls.  Used in conjunction with a custom url resolver, this can be used to load templateUrl templates in a node environment.

* **What is the current behavior?** (You can also link to an open issue here)

Current:

```
/usr/local/bin/node /usr/local/lib/node_modules/gulp/bin/gulp.js --color --gulpfile /example/gulpfile.ts
[18:09:27] Requiring external module ts-node/register
[18:09:32] Using gulpfile /example/gulpfile.ts
[18:09:32] Starting 'prerender'...
ngOnInit Error: Failed to load src/app.html
Async Error: Failed to load src/app.html
ngOnStable Error: Failed to load src/app.html
preboot Error: Failed to load src/app.html
EXCEPTION: Failed to load src/app.html
Rendering Document Error: Failed to load src/app.html
Unhandled Promise rejection: Failed to load src/app.html ; Zone: <root> ; Task: Promise.then ; Value: Failed to load src/app.html
ngOnRendered Error: Failed to load src/app.html
```

With URL resolver to load templates from disk:

```typescript
export class NodeUrlResolver extends UrlResolver {
  resolve(baseUrl: string, url: string): string {
    return `file://${path.resolve(path.join(ROOT, baseUrl, url))}`;
  }
}
```

```
/usr/local/bin/node /usr/local/lib/node_modules/gulp/bin/gulp.js --color --gulpfile /example/gulpfile.ts
[18:13:22] Requiring external module ts-node/register
[18:13:27] Using gulpfile /example/gulpfile.ts
[18:13:27] Starting 'prerender'...
EXCEPTION: Error during instantiation of Token Promise<ComponentRef>!.
ORIGINAL EXCEPTION: Error: Protocol "file:" not supported. Expected "http:".
ORIGINAL STACKTRACE:
Error: Protocol "file:" not supported. Expected "http:".
    at new ClientRequest (_http_client.js:53:11)
    at Object.exports.request (http.js:31:10)
    at Object.exports.get (http.js:35:21)
    at NodeXHRImpl.get (/example/node_modules/angular2-universal-preview/dist/node/platform/node_xhr_impl.js:29:14)
    at TemplateNormalizer.normalizeTemplate (angular2/src/compiler/template_normalizer.ts:42:24)
    at TemplateCompiler.normalizeDirectiveMetadata (angular2/src/compiler/template_compiler.ts:98:37)
    at angular2/src/compiler/template_compiler.ts:186:61
    at Array.map (native)
    at Object.Call (/example/node_modules/es6-shim/es6-shim.js:279:14)
    at Array.map (/example/node_modules/es6-shim/es6-shim.js:1275:17)
```

* **What is the new behavior (if this is a feature change)?**


With file protocol support in NodeXHRImpl:

```
/usr/local/bin/node /usr/local/lib/node_modules/gulp/bin/gulp.js --color --gulpfile /example/gulpfile.ts
[18:16:57] Requiring external module ts-node/register
[18:17:02] Using gulpfile /example/gulpfile.ts
[18:17:02] Starting 'prerender'...
EXCEPTION: Template parse errors:
Can't bind to 'href' since it isn't a known native property ("
        <span flex></span>
        <a md-peekaboo
           [ERROR ->][href]="https://github.com/justindujardin/ng2-material/releases/tag/v{{version}}"
           target=""): App@46:11
```

Which is another error in my project, but the template was properly loaded.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

I'm not sure if this is a terrible idea or not. It seems to work well enough. What do you think?