### PR TITLE
chore(universal): Downgrade zone to 0.6.8 (0.6.9 has bug)

### DIFF
--- a/modules/universal/package.json
+++ b/modules/universal/package.json
@@ -38,7 +38,7 @@
     "angular2-hapi-engine": "file:../hapi-engine",
     "preboot": "file:../preboot",
     "angular2": "2.0.0-beta.13",
-    "zone.js": "~0.6.6",
+    "zone.js": "~0.6.8",
     "es6-shim": "^0.35.0",
     "es6-promise": "^3.0.2",
     "reflect-metadata": "0.1.2",
@@ -62,7 +62,7 @@
     "angular2-hapi-engine": ">=0.7.2",
     "rxjs": "~5.0.0-beta.2",
     "angular2": "2.0.0-beta.12 - 2.0.0-beta.13",
-    "zone.js": "~0.6.6",
+    "zone.js": "~0.6.8",
     "css": "^2.2.1",
     "parse5": "^1.5.0"
   },


### PR DESCRIPTION
* **What modules are related to this pull-request**
- [X] universal-preview
- [X] universal

Bug fix.

Fixes `EXCEPTION: UnsubscriptionError` issue with ZoneJS

Related to issues #350 & #343 

As noted here in Zone issue, going to `0.6.8` should fix the issue.
https://github.com/angular/zone.js/issues/310
