### PR TITLE
feat(universal): Create install-all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,13 @@
   ],
   "scripts": {
     "clean:all": "rm -rf ./modules/*/dist ./modules/*/node_modules ./modules/*/typings */dist */node_modules */typings ./dist ./node_modules ./typings",
+    
+    "install:all" : "npm run install-preboot && npm run install-universal && npm run loop-install && npm install && typings install",
+
+    "loop-install" : "for dir in modules/[a-zA-Z0-9]* ; do printf \"=== Installing %s\\n\" \"$dir\" ; ( cd \"$dir\"; npm install && typings install; ) ;printf \"=== Installation exit code: %s for %s\\n\" $? \"$dir\" ; done",
+    "install-preboot"             : "cd ./modules/preboot && npm install",
+    "install-universal"           : "cd ./modules/universal && npm install",
+    
     "prestart": "gulp build",
     "build": "gulp build",
     "serve": "gulp serve",


### PR DESCRIPTION
Feature for:
- [X] universal

Feature addition:

Automatic script for installing the entire project & external modules.
Starting with Preboot, then Universal, then it installs all other modules as well as typings.
Afterwards it even `npm installs` the Universal repo itself.

Useage:

When Repo is pulled down simply run `npm run install:all` and it will take care of the rest. (*note: takes ~10 minutes to install all the node modules & typings for all modules/ projects & repo itself*)

Afterwards a dev can do `npm start`, and voila - Universal is up and running.
