### PR TITLE
fix(universal): Fix server file path to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 // Set up ts-node to enable loading of TypeScript files.
 require('ts-node/register');
-module.exports = require('./examples/src/server.ts');
+module.exports = require('./examples/src/index.ts');


### PR DESCRIPTION
Typo just fixing path to index.ts file in examples/src

![screen shot 2016-04-18 at 1 21 47 am](https://cloud.githubusercontent.com/assets/2574412/14594398/2b6cc98a-0504-11e6-9b30-ae633e1134f9.png)
