### PR TITLE
fix(preboot): no more type warnings and fixed broken unit test

### DIFF
--- a/modules/preboot/.gitignore
+++ b/modules/preboot/.gitignore
@@ -37,9 +37,9 @@ test/coverage
 /web_modules/
 
 # Typings
-/typings/browser
 /typings/main
-/typings/browser.d.ts
+/typings/browser
 /typings/main.d.ts
+/typings/browser.d.ts
 /tsd_typings
 /docs

--- a/modules/preboot/package.json
+++ b/modules/preboot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preboot",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Record and play back browser events",
   "main": "dist/src/node/preboot_node.js",
   "browser": "dist/src/browser/preboot_browser.js",
@@ -8,7 +8,8 @@
   "scripts": {
     "prebuild": "rm -rf dist",
     "build": "tsc || true",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "preinstall": "typings install"
   },
   "files": [
     "src",

--- a/modules/preboot/src/node/browser_code_generator.ts
+++ b/modules/preboot/src/node/browser_code_generator.ts
@@ -1,5 +1,5 @@
 import * as Q from 'q';
-import * as rename from 'gulp-rename';
+import rename = require('gulp-rename');  // hack to get working
 import * as uglify from 'gulp-uglify';
 import * as insert from 'gulp-insert';
 import * as eventStream from 'event-stream';

--- a/modules/preboot/test/node/normalize_spec.ts
+++ b/modules/preboot/test/node/normalize_spec.ts
@@ -86,7 +86,7 @@ describe('normalize', function () {
     it('should verify default', function () {
       let opts = { replay: null };
       normalizers.replay(opts);
-      expect(opts.replay).toEqual([]);
+      expect(opts.replay).toEqual([{ name: 'rerender' }]);
     });
 
     it('should throw an error if string not valid replay strategy', function () {

--- a/modules/preboot/typings.json
+++ b/modules/preboot/typings.json
@@ -2,7 +2,7 @@
   "ambientDependencies": {
     "browserify": "github:DefinitelyTyped/DefinitelyTyped/browserify/browserify.d.ts#abc2bcfb8524b1e027e6298d3348012b5b06eda5",
     "event-stream": "github:DefinitelyTyped/DefinitelyTyped/event-stream/event-stream.d.ts#14ba891ee5f5bf86d76c0dee99cbafc892febaf8",
-    "gulp-rename": "github:DefinitelyTyped/DefinitelyTyped/gulp-rename/gulp-rename.d.ts#03f12b0f667d29fe8e15c2e5c56f3ed7e10c8eb9",
+    "gulp-rename": "registry:dt/gulp-rename#0.0.0+20160316155526",
     "gulp-uglify": "github:DefinitelyTyped/DefinitelyTyped/gulp-uglify/gulp-uglify.d.ts#ba956a3e6e8ebb82d33548209f793234efac44a2",
     "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#dd638012d63e069f2c99d06ef4dcc9616a943ee4",
     "lodash": "github:DefinitelyTyped/DefinitelyTyped/lodash/lodash-3.10.d.ts#86dbea8fc37d9473fee465da4f0a21bea4f8cbd9",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [X] preboot
- [ ] universal-preview
- [ ] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files

Added missing type definitions and fixed broken unit test.

* **What is the current behavior?** (You can also link to an open issue here)

Warnings when you do `gulp tsc`

* **What is the new behavior (if this is a feature change)?**

Clean build and clean tests

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

