### PR TITLE
fix(install): do not use globally installed typings in preinstall

### DIFF
--- a/modules/preboot/package.json
+++ b/modules/preboot/package.json
@@ -6,10 +6,10 @@
   "browser": "dist/src/browser/preboot_browser.js",
   "typings": "dist/src/node/preboot_node.d.ts",
   "scripts": {
-    "prebuild": "rm -rf dist",
-    "build": "tsc || true",
+    "prebuild": "./node_modules/.bin/del -rf dist",
+    "build": "./node_modules/.bin/tsc || true",
     "prepublish": "npm run build",
-    "preinstall": "typings install"
+    "postinstall": "./node_modules/.bin/typings install"
   },
   "files": [
     "src",
@@ -56,7 +56,9 @@
     "lodash": "^4.7.0",
     "q": "^1.4.1",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "typings": "^0.8.1",
+    "del-cli": "0.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [*] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [*] preboot
- [ ] universal-preview
- [ ] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files
Fixing of preboot installation

* **What is the current behavior?** (You can also link to an open issue here)

right now there are an exception on trying to clean install universal with preboot depency

```bash
npm ERR! preboot@2.0.7 preinstall: `typings install`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the preboot@2.0.7 preinstall script 'typings install'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the preboot package,
```


* **What is the new behavior (if this is a feature change)?**
works just fine


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
