### PR TITLE
feature(preboot): adding option to disable code caching between calls…

### DIFF
--- a/modules/preboot/package.json
+++ b/modules/preboot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preboot",
-  "version": "2.0.10",
+  "version": "2.1.0",
   "description": "Record and play back browser events",
   "main": "dist/src/node/preboot_node.js",
   "browser": "dist/src/browser/preboot_browser.js",

--- a/modules/preboot/src/interfaces/preboot_options.ts
+++ b/modules/preboot/src/interfaces/preboot_options.ts
@@ -22,4 +22,5 @@ export interface PrebootOptions {
     uglify?: boolean;             // if true, client code generated will be uglified
     buffer?: boolean;             // if true, attempt to buffer client rendering to hidden div
     debug?: boolean;              // if true, output console logs on the client with runtime info about preboot
+    disableCodeCache?: boolean;   // if true, preboot won't cache the generated code
 }

--- a/modules/preboot/src/node/browser_code_generator.ts
+++ b/modules/preboot/src/node/browser_code_generator.ts
@@ -83,9 +83,9 @@ export function getBrowserCode(opts?: PrebootOptions, done?: Function): any {
   let deferred = Q.defer();
   let clientCode = '';
 
-  // check cache first
+  // check cache first (as long as it wasn't disabled)
   let cacheKey = JSON.stringify(opts);
-  if (browserCodeCache[cacheKey]) {
+  if (!opts.disableCodeCache && browserCodeCache[cacheKey]) {
     return Q.when(browserCodeCache[cacheKey]);
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [X] preboot
- [ ] universal-preview
- [ ] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files

Feature to disable code caching in preboot in between calls.

* **What is the current behavior?** (You can also link to an open issue here)

If you call preboot multiple times, it caches the generated code.

* **What is the new behavior (if this is a feature change)?**

Same by default, but user can do `disableCodeCache: true` to disable code caching.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

… to preboot