### PR TITLE
fix(universal): make originUrl optional in node_xhr_impl

### DIFF
--- a/modules/universal/src/node/platform/node_xhr_impl.ts
+++ b/modules/universal/src/node/platform/node_xhr_impl.ts
@@ -11,7 +11,7 @@ export class NodeXHRImpl extends XHR {
   _baseUrl: string;
   constructor(
     public ngZone: NgZone,
-    @Inject(ORIGIN_URL) private _originUrl: string = '',
+    @Optional() @Inject(ORIGIN_URL) private _originUrl: string = '',
     @Optional() @Inject(BASE_URL) _baseUrl?: string) {
     super();
     this._baseUrl = _baseUrl || '/';


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] preboot
- [ ] universal-preview
- [x] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files

Adds DI annotation to originUrl parameter in node_xhr_impl to make it optional.

* **What is the current behavior?** (You can also link to an open issue here)
Parameter is required.


* **What is the new behavior (if this is a feature change)?**
Parameter is optional


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

The parameter already defaults to an empty string if not specified,
so this fix makes the parameter completely optional.