### PR TITLE
fix(broccoli-prerender): merge providers and platformProviders when serializing app

### DIFF
--- a/modules/broccoli-prerender/package.json
+++ b/modules/broccoli-prerender/package.json
@@ -2,7 +2,7 @@
   "name": "angular2-broccoli-prerender",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "version": "0.11.0",
+  "version": "0.11.2",
   "description": "Prerender your Universal (isomorphic) Angular 2 app",
   "homepage": "https://github.com/angular/universal",
   "license": "MIT",

--- a/modules/broccoli-prerender/src/prerender.ts
+++ b/modules/broccoli-prerender/src/prerender.ts
@@ -25,7 +25,9 @@ export class AppShellPlugin extends BroccoliPlugin {
       document: Bootloader.parseDocument(sourceHtml),
     });
     var bootloader = Bootloader.create(options);
-    return bootloader.serializeApplication(null, options.providers)
+    // Make sure to get all providers and platformProviders
+    var providers = [].concat(options.providers || []).concat(options.platformProviders || []);
+    return bootloader.serializeApplication(null, providers)
       .then(html =>  fs.writeFileSync(path.resolve(this.outputPath, this.indexPath), html, 'utf-8'));
   }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
 - [x] broccoli-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Only includes `providers` from config, ignores `platformProviders`, causes DI errors.


* **What is the new behavior (if this is a feature change)?**
Merges `providers` and `platformProviders` from config.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
