### PR TITLE
build: change rm -rf to rimraf to prevent npm install fail on win env

### DIFF
--- a/modules/broccoli-prerender/package.json
+++ b/modules/broccoli-prerender/package.json
@@ -13,9 +13,9 @@
     "Jeff Cross <crossj@google.com>"
   ],
   "scripts": {
-    "remove-modules": "rm -rf dist node_modules/preboot node_modules/angular2-universal-preview node_modules/angular2-universal",
+    "remove-modules": "rimraf dist node_modules/preboot node_modules/angular2-universal-preview node_modules/angular2-universal",
     "reload": "npm run remove-modules && npm install",
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc || true",
     "prepublish": "npm run build"
   },

--- a/modules/express-engine/package.json
+++ b/modules/express-engine/package.json
@@ -12,9 +12,9 @@
     "Jeff Whelpley <jeff@gethuman.com>"
   ],
   "scripts": {
-    "remove-modules": "rm -rf node_modules/angular2-universal-preview node_modules/angular2-universal node_modules/angular2-express-engine node_modules/preboot node_modules/angular2-hapi-engine node_modules/angular2-universal-polyfills node_modules/zone.js",
+    "remove-modules": "rimraf node_modules/angular2-universal-preview node_modules/angular2-universal node_modules/angular2-express-engine node_modules/preboot node_modules/angular2-hapi-engine node_modules/angular2-universal-polyfills node_modules/zone.js",
     "reload": "npm run remove-modules && npm install",
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc || true",
     "prepublish": "npm run build"
   },
@@ -38,7 +38,8 @@
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.6",
     "typescript": "^1.8.10",
-    "zone.js": "^0.6.12"
+    "zone.js": "^0.6.12",
+    "rimraf": "^2.5.1"
   },
   "dependencies": {
   },

--- a/modules/grunt-prerender/package.json
+++ b/modules/grunt-prerender/package.json
@@ -12,9 +12,9 @@
     "Jeff Whelpley <jeff@gethuman.com>"
   ],
   "scripts": {
-    "remove-modules": "rm -rf node_modules/angular2-universal-preview node_modules/angular2-universal node_modules/angular2-express-engine node_modules/preboot node_modules/angular2-hapi-engine node_modules/angular2-universal-polyfills node_modules/zone.js",
+    "remove-modules": "rimraf node_modules/angular2-universal-preview node_modules/angular2-universal node_modules/angular2-express-engine node_modules/preboot node_modules/angular2-hapi-engine node_modules/angular2-universal-polyfills node_modules/zone.js",
     "reload": "npm run remove-modules && npm install",
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc || true",
     "prepublish": "npm run build"
   },

--- a/modules/gulp-prerender/package.json
+++ b/modules/gulp-prerender/package.json
@@ -12,9 +12,9 @@
     "Jeff Whelpley <jeff@gethuman.com>"
   ],
   "scripts": {
-    "remove-modules": "rm -rf dist node_modules/preboot node_modules/angular2-universal-preview node_modules/angular2-universal",
+    "remove-modules": "rimraf dist node_modules/preboot node_modules/angular2-universal-preview node_modules/angular2-universal",
     "reload": "npm run remove-modules && npm install",
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc || true",
     "prepublish": "npm run build"
   },

--- a/modules/hapi-engine/package.json
+++ b/modules/hapi-engine/package.json
@@ -12,9 +12,9 @@
     "Jeff Whelpley <jeff@gethuman.com>"
   ],
   "scripts": {
-    "remove-modules": "rm -rf node_modules/angular2-universal-preview node_modules/angular2-universal node_modules/angular2-express-engine node_modules/preboot node_modules/angular2-hapi-engine node_modules/angular2-universal-polyfills",
+    "remove-modules": "rimraf node_modules/angular2-universal-preview node_modules/angular2-universal node_modules/angular2-express-engine node_modules/preboot node_modules/angular2-hapi-engine node_modules/angular2-universal-polyfills",
     "reload": "npm run remove-modules && npm install",
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc || true",
     "postbuild": "typings install",
     "prepublish": "npm run build"

--- a/modules/polyfills/package.json
+++ b/modules/polyfills/package.json
@@ -30,11 +30,12 @@
     "test.js"
   ],
   "scripts": {
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc || true",
     "prepublish": "npm run build"
   },
   "devDependencies": {
+    "rimraf": "^2.5.2",
     "typescript": "^1.8.9"
   },
   "dependencies": {

--- a/modules/preboot/package.json
+++ b/modules/preboot/package.json
@@ -6,8 +6,8 @@
   "browser": "dist/src/browser/preboot_browser.js",
   "typings": "dist/src/node/preboot_node.d.ts",
   "scripts": {
-    "prebuild": "./node_modules/.bin/rimraf dist",
-    "build": "./node_modules/.bin/tsc || true",
+    "prebuild": "rimraf dist",
+    "build": "tsc || true",
     "prepublish": "npm run build"
   },
   "files": [
@@ -43,6 +43,7 @@
     "serve-static": "^1.10.2",
     "tslint": "^3.6.0",
     "typescript": "^1.8.9",
+    "rimraf": "^2.5.2",
     "watchify": "^3.7.0"
   },
   "dependencies": {

--- a/modules/universal/package.json
+++ b/modules/universal/package.json
@@ -31,9 +31,9 @@
     "mock.js"
   ],
   "scripts": {
-    "remove-modules": "rm -rf node_modules/angular2-universal-preview node_modules/angular2-universal node_modules/angular2-express-engine node_modules/preboot node_modules/angular2-hapi-engine node_modules/angular2-universal-polyfills",
+    "remove-modules": "rimraf node_modules/angular2-universal-preview node_modules/angular2-universal node_modules/angular2-express-engine node_modules/preboot node_modules/angular2-hapi-engine node_modules/angular2-universal-polyfills",
     "reload": "npm run remove-modules && npm install && npm install",
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc || true",
     "prepublish": "npm run build"
   },
@@ -58,6 +58,7 @@
     "typescript": "~1.8.10",
     "rxjs": "5.0.0-beta.6",
     "css": "^2.2.1",
+    "rimraf": "^2.5.2",
     "parse5": "^1.5.0"
   },
   "dependencies": {

--- a/modules/webpack-prerender/package.json
+++ b/modules/webpack-prerender/package.json
@@ -11,9 +11,9 @@
     "Jeff Whelpley <jeff@gethuman.com>"
   ],
   "scripts": {
-    "remove-modules": "rm -rf dist node_modules/preboot node_modules/angular2-universal-preview node_modules/angular2-universal",
+    "remove-modules": "rimraf dist node_modules/preboot node_modules/angular2-universal-preview node_modules/angular2-universal",
     "reload": "npm run remove-modules && npm install",
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc || true",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
Closes #402 
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [x] express-engine
- [x] grunt-prerender
- [x] gulp-prerender
- [x] hapi-engine
- [ ] preboot
- [ ] universal-preview
- [x] angular2-universal-polyfills
- [x] universal
- [x] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 change rm -rf to rimraf to prevent npm install fail on win env


* **What is the current behavior?** (You can also link to an open issue here)
See issue #402 


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

