### PR TITLE
feat(universal-cookie): basic implementation of universal cookie

### DIFF
--- a/modules/universal/src/common/tokens/index.ts
+++ b/modules/universal/src/common/tokens/index.ts
@@ -8,3 +8,5 @@ export const REQUEST_URL: OpaqueToken = new OpaqueToken('requestUrl');
 export const BASE_URL: OpaqueToken = APP_BASE_HREF;
 
 export const PRIME_CACHE: OpaqueToken = new OpaqueToken('primeCache');
+
+export const REQUEST_COOKIE: OpaqueToken = new OpaqueToken('requestCookie');

--- a/modules/universal/src/node/http/node_http.ts
+++ b/modules/universal/src/node/http/node_http.ts
@@ -18,7 +18,7 @@ import * as http from 'http';
 import * as https from 'https';
 import * as url from 'url';
 
-import {ORIGIN_URL, BASE_URL} from '../../common';
+import {ORIGIN_URL, BASE_URL, REQUEST_COOKIE, Cookie} from '../../common';
 
 export class NodeConnection implements Connection {
   public readyState: ReadyState;
@@ -30,7 +30,8 @@ export class NodeConnection implements Connection {
     baseResponseOptions: ResponseOptions,
     ngZome: NgZone,
     @Inject(ORIGIN_URL) originUrl: string = '',
-    @Optional() @Inject(BASE_URL) baseUrl?: string) {
+    @Optional() @Inject(BASE_URL) baseUrl?: string,
+    @Optional() @Inject(REQUEST_COOKIE) requestCookie?: Cookie) {
 
     this.request = req;
     baseUrl = baseUrl || '/';
@@ -41,6 +42,14 @@ export class NodeConnection implements Connection {
 
     let _reqInfo: any = url.parse(url.resolve(url.resolve(originUrl, baseUrl), req.url));
     _reqInfo.method = RequestMethod[req.method].toUpperCase();
+
+    if (isPresent(requestCookie)){
+      if (!isPresent(req.headers)){
+        req.headers = new Headers();
+      }
+
+      req.headers.append('Cookie', requestCookie.get());
+    }
 
     if (isPresent(req.headers)) {
       _reqInfo.headers = {};


### PR DESCRIPTION
Related to issues: #273, and _https://github.com/aspnet/NodeServices/issues/66_

This is pretty easy fix, just to enable possibility to integrate server request cookie

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] preboot
- [ ] universal-preview
- [x] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files


* **What is the current behavior?** (You can also link to an open issue here)
Currently cookies not handled, just abstract class provided.


* **What is the new behavior (if this is a feature change)?**
Provided abstract class injected as optional parameter to node_http, so we could grab cookie string from it. It provide abiliti to inject this cookie object from server. Here is some sample boot-server, that i use with my aspnet prerenderer:
```
import 'angular2-universal/polyfills';
import * as ngCore from '@angular/core';
import * as ngRouter from '@angular/router-deprecated';
import * as ngUniversal from 'angular2-universal';
import * as aspnet from 'aspnet-prerendering';
import { Cookie } from './components/shared/Cookie';
import { BASE_URL, ORIGIN_URL, REQUEST_URL, REQUEST_COOKIE } from 'angular2-universal/common';
import { App } from './components/app/app';

export default function (params: aspnet.BootFuncParams): Promise<{ html: string, globals?: any }> {
  let cookie = new Cookie(params.cookie); // params.cookie populated on aspnet server and pass to boot function
  const serverBindings = [
    ngCore.provide(BASE_URL, { useValue: '/' }),
    ngCore.provide(ORIGIN_URL, { useValue: params.origin }),
    ngCore.provide(REQUEST_URL, { useValue: params.url }),
    ngCore.provide(REQUEST_COOKIE, { useValue: cookie }), // provide cookie to ng2-universal
    ...ngUniversal.NODE_PLATFORM_PIPES,
    ...ngUniversal.NODE_ROUTER_PROVIDERS,
    ...ngUniversal.NODE_HTTP_PROVIDERS,
  ];

  let boot = ngUniversal.bootloader({
    directives: [App],
    componentProviders: serverBindings,
    async: true,
    preboot: false,
    // TODO: Render just the <app> component instead of wrapping it inside an extra HTML document
    // Waiting on https://github.com/angular/universal/issues/347
    template: '<!DOCTYPE html>\n<html><head></head><body><app></app></body></html>'
  })

  // aspnet-prerender specific code
  return boot.serializeApplication().then(html => {
    boot.dispose();
    return { html };
  });
}
```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

- add opaque token to be able inject cookie object
- add optional request cookie object into node_http service