### PR TITLE
fix(universal): fix bootloader preboot config handling

### DIFF
--- a/modules/universal/src/node/bootloader.ts
+++ b/modules/universal/src/node/bootloader.ts
@@ -166,7 +166,7 @@ export class Bootloader {
         console.log('ngOnStable Error:', err);
       })
       .then((configRefs: ConfigRefs) => {
-        if ('preboot' in this._config && !this._config.preboot) {
+        if ('preboot' in this._config && this._config.preboot) {
           let promise: any = this._preboot(configRefs);
           return promise;
         } else {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

I couldn't exec `npm run test`...

```
$ node -v
v6.2.0
$ npm run test

> angular2-universal@0.0.1 test /Users/vvakame/Dropbox/work/ng-ssr-cli/angular2-universal
> gulp karma

(node:48562) fs: re-evaluating native module sources is not supported. If you are using the graceful-fs module, please update it to a more recent version.
```

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [x] preboot
- [ ] universal-preview
- [ ] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.
We can't get code generation result with preboot by Bootloader#serializeApplication.

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/angular/universal/blob/805625d40e4b71d74159172506425e5002d4dbfa/modules/universal/src/node/bootloader.ts#L169
if config has `preboot: true` property, bootloader don't call `this._preboot` method. it is unexpected.

* **What is the new behavior (if this is a feature change)?**

if config has `preboot: true` or truthy value, bootloader call `this._preboot` method.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

I found this bug in develop [ng-ssr-cli](https://www.npmjs.com/package/ng-ssr-cli).