### PR TITLE
chore: replace private imports with copies of utility functions

### DIFF
--- a/modules/universal/src/browser/bootstrap.ts
+++ b/modules/universal/src/browser/bootstrap.ts
@@ -1,7 +1,5 @@
-import {Type} from '@angular/core/src/facade/lang';
-import {Provider} from '@angular/core';
+import { ComponentRef, Type, Provider } from '@angular/core';
 import {bootstrap as bootstrapClient} from '@angular/platform-browser-dynamic';
-import {ComponentRef} from '@angular/core/src/linker/component_factory';
 
 var prebootCompleted = false;
 

--- a/modules/universal/src/browser/ng_preload_cache.ts
+++ b/modules/universal/src/browser/ng_preload_cache.ts
@@ -7,10 +7,6 @@ import {
   ConnectionBackend,
   XHRBackend
 } from '@angular/http';
-import {
-  isPresent,
-  isBlank
-} from '@angular/core/src/facade/lang';
 
 import {
   provide,
@@ -23,6 +19,10 @@ import {
 
 import {Observable} from 'rxjs/Observable';
 
+import {
+  isPresent,
+  isBlank
+} from '../common';
 
 @Injectable()
 export class NgPreloadCacheHttp extends Http {

--- a/modules/universal/src/common/index.ts
+++ b/modules/universal/src/common/index.ts
@@ -3,3 +3,4 @@ export * from './tokens';
 export * from './cookie';
 export * from './localStorage';
 export * from './title';
+export * from './utils';

--- a/modules/universal/src/common/utils.ts
+++ b/modules/universal/src/common/utils.ts
@@ -1,0 +1,27 @@
+// Copied from @angular/core/facade/lang.ts
+export function isPresent(obj: any): boolean {
+  return obj !== undefined && obj !== null;
+}
+
+export function isBlank(obj: any): boolean {
+  return obj === undefined || obj === null;
+}
+
+export function regExFirstMatch (regExp: RegExp, input: string): RegExpExecArray {
+  regExp.lastIndex = 0;
+  return regExp.exec(input);
+}
+
+// Copied from @angular/facade/src/collection.ts
+export const listContains = (list: any[], el: any): boolean => list.indexOf(el) !== -1;
+
+export function stringMapForEach(map: {[key: string]: any}, callback: (V, K) => void) {
+  for (var prop in map) {
+      if (map.hasOwnProperty(prop)) {
+        callback(map[prop], prop);
+      }
+    }
+}
+
+// Copied from @angular/http/src/http_utils.ts
+export const isSuccess = (status: number): boolean => (status >= 200 && status < 300);

--- a/modules/universal/src/node/directives/node_form.ts
+++ b/modules/universal/src/node/directives/node_form.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 
 import {Renderer} from '@angular/core';
-import {isPresent} from '@angular/core/src/facade/lang';
+import {isPresent} from '../../common';
 
 const CONST_EXPR = v => v;
 export const APP_LOCATION: OpaqueToken = CONST_EXPR(new OpaqueToken('appLocation'));

--- a/modules/universal/src/node/http/node_http.ts
+++ b/modules/universal/src/node/http/node_http.ts
@@ -9,17 +9,21 @@ import {
   ResponseOptions,
   ResponseType
 } from '@angular/http';
-import * as utils from '@angular/http/src/http_utils';
-import {isPresent, StringWrapper} from '@angular/core/src/facade/lang';
 import {Injectable, NgZone, Inject, Optional} from '@angular/core';
-import {makeTypeError} from '@angular/core/src/facade/exceptions';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import * as http from 'http';
 import * as https from 'https';
 import * as url from 'url';
 
-import {ORIGIN_URL, BASE_URL, COOKIE_KEY, Cookie} from '../../common';
+import {
+  ORIGIN_URL,
+  BASE_URL,
+  COOKIE_KEY,
+  Cookie,
+  isPresent,
+  isSuccess
+} from '../../common';
 
 const JSONP_ERR_WRONG_METHOD = 'JSONP requests must use GET request method.';
 
@@ -92,7 +96,7 @@ export class NodeConnection implements Connection {
             let responseOptions = new ResponseOptions({body, status, headers, url});
             let response = new Response(responseOptions);
 
-            if (utils.isSuccess(status)) {
+            if (isSuccess(status)) {
               ngZone.run(() => {
                 responseObserver.next(response);
               });
@@ -145,7 +149,7 @@ class NodeJSONPConnection {
     @Optional() @Inject(BASE_URL) baseUrl?: string) {
 
     if (req.method !== RequestMethod.Get) {
-      throw makeTypeError(JSONP_ERR_WRONG_METHOD);
+      throw new TypeError(JSONP_ERR_WRONG_METHOD);
     }
 
 
@@ -200,7 +204,7 @@ class NodeJSONPConnection {
             let responseOptions = new ResponseOptions({body: responseJson, status, headers, url});
             let response = new Response(responseOptions);
 
-            if (utils.isSuccess(status)) {
+            if (isSuccess(status)) {
               ngZone.run(() => {
                 responseObserver.next(response);
               });

--- a/modules/universal/src/node/http/preload_cache.ts
+++ b/modules/universal/src/node/http/preload_cache.ts
@@ -31,15 +31,12 @@ import {
 } from '@angular/http';
 import {MockBackend} from '@angular/http/testing';
 
-
-import {isPresent, isBlank} from '@angular/core/src/facade/lang';
-
 // CJS
 import {XMLHttpRequest} from 'xhr2';
 // import XMLHttpRequest = require('xhr2');
 
 
-import {ORIGIN_URL, BASE_URL, PRIME_CACHE} from '../../common';
+import {ORIGIN_URL, BASE_URL, PRIME_CACHE, isPresent, isBlank} from '../../common';
 
 const CONST_EXPR = v => v;
 

--- a/modules/universal/src/node/platform/dom/node_dom_renderer.ts
+++ b/modules/universal/src/node/platform/dom/node_dom_renderer.ts
@@ -1,10 +1,4 @@
 import {
-  isPresent,
-  isBlank,
-  stringify
-} from '@angular/core/src/facade/lang';
-import {ListWrapper} from '@angular/core/src/facade/collection';
-import {
   provide,
   Inject,
   Injectable,
@@ -21,6 +15,12 @@ import {DomSharedStylesHost} from '@angular/platform-browser/src/dom/shared_styl
 import {ViewEncapsulation} from '@angular/core';
 
 import {cssHyphenate} from '../../helper';
+
+import {
+  isPresent,
+  isBlank,
+  listContains
+} from '../../../common';
 
 import {Parse5DomAdapter} from '@angular/platform-server';
 Parse5DomAdapter.makeCurrent(); // ensure Parse5DomAdapter is used
@@ -222,7 +222,7 @@ export class NodeDomRenderer extends DomRenderer {
     let el = DOM.nodeName(renderElement);
     let attrList = ATTRIBUTES[el];
     if (attrList) {
-      let booleanAttr = ListWrapper.contains(attrList, propertyName);
+      let booleanAttr = listContains(attrList, propertyName);
       if (booleanAttr) {
         if (propertyName === 'autocomplete') {
           return this._setOnOffAttribute(renderElement, propertyName, propertyValue);
@@ -251,7 +251,7 @@ export class NodeDomRenderer extends DomRenderer {
     }
     return super.invokeElementMethod(location, methodName, args);
   }
-  
+
   _setCheckedAttribute(renderElement, propertyName, propertyValue) {
     if (isPresent(propertyValue)) {
       if (propertyValue === true) {

--- a/modules/universal/src/node/platform/node.ts
+++ b/modules/universal/src/node/platform/node.ts
@@ -1,6 +1,3 @@
-// Facade
-import {Type, isPresent} from '@angular/core/src/facade/lang';
-
 // Compiler
 import {COMPILER_PROVIDERS, XHR} from '@angular/compiler';
 
@@ -28,7 +25,8 @@ import {
   ExceptionHandler,
   Renderer,
   NgZone,
-  OpaqueToken
+  OpaqueToken,
+  Type
 } from '@angular/core';
 
 // Common
@@ -61,8 +59,9 @@ import {NODE_PLATFORM_DIRECTIVES} from '../directives';
 
 var CONST_EXPR = v => v;
 import {Parse5DomAdapter} from '@angular/platform-server';
-Parse5DomAdapter.makeCurrent(); // ensure Parse5DomAdapter is used
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import {isPresent} from '../../common';
+Parse5DomAdapter.makeCurrent(); // ensure Parse5DomAdapter is used
 var DOM: any = getDOM();
 var isRc0 = require('@angular/core/package.json').version.indexOf('-rc.0') !== -1;
 

--- a/modules/universal/src/node/platform/node_shared_styles_host.ts
+++ b/modules/universal/src/node/platform/node_shared_styles_host.ts
@@ -1,6 +1,4 @@
 import {Inject, Injectable} from '@angular/core';
-import {SetWrapper} from '@angular/core/src/facade/collection';
-import {DOCUMENT} from '@angular/platform-browser/src/dom/dom_tokens';
 import {SharedStylesHost} from '@angular/platform-browser/src/dom/shared_styles_host';
 
 import {Parse5DomAdapter} from '@angular/platform-server';
@@ -26,7 +24,7 @@ export class NodeSharedStylesHost extends SharedStylesHost {
     this._hostNodes.add(hostNode);
   }
   removeHost(hostNode: Node) {
-    SetWrapper.delete(this._hostNodes, hostNode);
+    this._hostNodes.delete(hostNode);
   }
 
   onStylesAdded(additions: string[]) {

--- a/modules/universal/src/node/platform/node_xhr_impl.ts
+++ b/modules/universal/src/node/platform/node_xhr_impl.ts
@@ -5,7 +5,6 @@ import * as fs from 'fs';
 import {ORIGIN_URL, BASE_URL} from '../../common';
 import {NgZone, Inject, Optional} from '@angular/core';
 import {XHR} from '@angular/compiler';
-import {PromiseWrapper, PromiseCompleter} from '@angular/core/src/facade/promise';
 
 export class NodeXHRImpl extends XHR {
   _baseUrl: string;
@@ -18,55 +17,54 @@ export class NodeXHRImpl extends XHR {
   }
 
   get(templateUrl: string): Promise<string> {
-    const completer: PromiseCompleter<string> = PromiseWrapper.completer();
     const parsedUrl = url.parse(url.resolve(url.resolve(this._originUrl, this._baseUrl), templateUrl));
-
-    if (parsedUrl.protocol === 'file:') {
-      this.ngZone.run(() => {
-        fs.readFile(parsedUrl.path, (err, data) => {
-          if (err) {
-            return completer.reject(`Failed to load ${templateUrl} with error ${err}`);
-          }
-          this.ngZone.run(() => {
-            completer.resolve(data.toString());
-          });
-        });
-      });
-    } else {
-      this.ngZone.run(() => {
-        http.get(parsedUrl, (res) => {
-          res.setEncoding('utf8');
-
-          const status = res.statusCode;
-
-          if (200 <= status && status <= 300) {
-            let data = '';
-
-            res.on('data', (chunk) => {
-              data += chunk;
-            });
-            res.on('end', () => {
-              this.ngZone.run(() => {
-                completer.resolve(data);
-              });
-            });
-
-          } else {
+    return new Promise((resolve, reject) => {
+      if (parsedUrl.protocol === 'file:') {
+        // TODO(jeffbcross): is this promise already zone-aware/patched?
+        this.ngZone.run(() => {
+          fs.readFile(parsedUrl.path, (err, data) => {
+            if (err) {
+              return reject(`Failed to load ${templateUrl} with error ${err}`);
+            }
             this.ngZone.run(() => {
-              completer.reject(`Failed to load ${templateUrl}`, null);
+              resolve(data.toString());
             });
-          }
-
-          // consume response body
-          res.resume();
-        }).on('error', (e) => {
-          this.ngZone.run(() => {
-            completer.reject(`Failed to load ${templateUrl}`, null);
           });
         });
-      });
-    }
+      } else {
+        this.ngZone.run(() => {
+          http.get(parsedUrl, (res) => {
+            res.setEncoding('utf8');
 
-    return completer.promise;
+            const status = res.statusCode;
+
+            if (200 <= status && status <= 300) {
+              let data = '';
+
+              res.on('data', (chunk) => {
+                data += chunk;
+              });
+              res.on('end', () => {
+                this.ngZone.run(() => {
+                  resolve(data);
+                });
+              });
+
+            } else {
+              this.ngZone.run(() => {
+                reject(`Failed to load ${templateUrl}`);
+              });
+            }
+
+            // consume response body
+            res.resume();
+          }).on('error', (e) => {
+            this.ngZone.run(() => {
+              reject(`Failed to load ${templateUrl}`);
+            });
+          });
+        });
+      }
+    });
   }
 }

--- a/modules/universal/src/node/render.ts
+++ b/modules/universal/src/node/render.ts
@@ -20,14 +20,13 @@ import {
   createPrebootCode
 } from './ng_preboot';
 
-import {isBlank, isPresent} from '@angular/core/src/facade/lang';
-
 import {SharedStylesHost} from '@angular/platform-browser/src/dom/shared_styles_host';
 
 import {NgZone, ComponentRef, Provider, Type} from '@angular/core';
 import {Http} from '@angular/http';
 import {Router} from '@angular/router-deprecated';
 
+import {isBlank, isPresent} from '../common';
 
 
 export function waitRouter(appRef: ComponentRef<any>): Promise<ComponentRef<any>> {

--- a/modules/universal/src/node/stringify_element.ts
+++ b/modules/universal/src/node/stringify_element.ts
@@ -1,11 +1,8 @@
 // dom closure
-
-import {ListWrapper, MapWrapper} from '@angular/core/src/facade/collection';
-import {isPresent, isString, StringWrapper} from '@angular/core/src/facade/lang';
-
 import {Parse5DomAdapter} from '@angular/platform-server';
 Parse5DomAdapter.makeCurrent(); // ensure Parse5DomAdapter is used
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import {isPresent, listContains} from '../common';
 var DOM: any = getDOM();
 
 var _singleTagWhitelist = ['br', 'hr', 'input'];
@@ -23,7 +20,7 @@ export function stringifyElement(el): string {
     for (let i = 0; i < keys.length; i++) {
       var key = keys[i];
       var attValue = attributeMap.get(key);
-      if (!isString(attValue)) {
+      if (!(typeof attValue === 'string')) {
         result += ` ${key}`;
       } else {
         result += ` ${key}="${attValue}"`;
@@ -36,7 +33,7 @@ export function stringifyElement(el): string {
       result += stringifyElement(children[j]);
     }
     // Closing tag
-    if (!ListWrapper.contains(_singleTagWhitelist, tagName)) {
+    if (!listContains(_singleTagWhitelist, tagName)) {
       result += `</${tagName}>`;
     }
   } else if (DOM.isCommentNode(el)) {


### PR DESCRIPTION
This PR gets rid of many of the deep imports from Angular. For utility functions from Angular facade, I copied some of the useful ones into `universal/src/common/utilities.ts`. For simpler utility functions, I just inlined it.

This leaves just a few files that are using deep imports: 
 * modules/universal/src/node/platform/node_template_parser.ts
 * modules/universal/src/node/platform/node_template_parser-rc.0.ts
 * modules/universal/src/node/platform/node.ts

_Most_ of what those modules are importing from deep paths is types that are just used for type information. 