### PR TITLE
chore(webpack-prerender): update plugin and deps

### DIFF
--- a/modules/webpack-prerender/package.json
+++ b/modules/webpack-prerender/package.json
@@ -25,14 +25,14 @@
     "url": "https://github.com/angular/universal/issues"
   },
   "devDependencies": {
-    "@angular/common": "2.0.0-rc.1",
-    "@angular/compiler": "2.0.0-rc.1",
-    "@angular/core": "2.0.0-rc.1",
-    "@angular/http": "2.0.0-rc.1",
-    "@angular/platform-browser": "2.0.0-rc.1",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
-    "@angular/platform-server": "2.0.0-rc.1",
-    "@angular/router-deprecated": "2.0.0-rc.1",
+    "@angular/common": "2.0.0-rc.3",
+    "@angular/compiler": "2.0.0-rc.3",
+    "@angular/core": "2.0.0-rc.3",
+    "@angular/http": "2.0.0-rc.3",
+    "@angular/platform-browser": "2.0.0-rc.3",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.3",
+    "@angular/platform-server": "2.0.0-rc.3",
+    "@angular/router-deprecated": "2.0.0-rc.2",
     "preboot": "file:../preboot",
     "angular2-universal": "file:../universal",
     "rimraf": "^2.5.1",
@@ -43,6 +43,6 @@
   "dependencies": {
   },
   "peerDependencies": {
-    "angular2-universal": ">=0.100.3"
+    "angular2-universal": "^0.104.0"
   }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] preboot
- [ ] universal-preview
- [ ] universal
- [x] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update `webpack-prerender` to work with latest `angular2-universal`.


* **What is the current behavior?** (You can also link to an open issue here)
`webpack-prerender` doesn't work with latest `angular2-universal`.


* **What is the new behavior (if this is a feature change)?**
`webpack-prerender` works with latest `angular2-universal`.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. Users will need to change the `options` object sent to `angular2-webpack-prerender` to match `IWebpackPrerender`, see https://github.com/angular/universal/pull/455/files#diff-93ba43a533f39d2855c23219f33143bdR4


* **Other information**:
Could not find existing tests or docs for this functionality so I did not update them.
