### PR TITLE
refactor(webpack-prerender): decouple config from plugin

### DIFF
--- a/modules/webpack-prerender/README.md
+++ b/modules/webpack-prerender/README.md
@@ -1,0 +1,72 @@
+# angular2-webpack-prerender
+
+This webpack plugin is meant to be used together with a prerender entry file 
+exporting two functions:
+- `getBootloader`, which returns a Bootloader
+- `serialize`, which takes a Bootloader and a template string
+
+```
+// ./src/prerender-entry-file.ts
+import 'angular2-universal-polyfills';
+import { provide } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
+import { 
+  REQUEST_URL, 
+  ORIGIN_URL, 
+  Bootloader, 
+  BootloaderConfig, 
+  AppConfig 
+} from 'angular2-universal';
+import { AppComponent } from './app/';
+
+const bootloaderConfig: BootloaderConfig = {
+  platformProviders: [
+    provide(ORIGIN_URL, {
+      useValue: 'http://localhost:4200' // full urls are needed for node xhr
+    }),
+    provide(APP_BASE_HREF, { useValue: '/' }),
+  ],
+  async: true,
+  preboot: false
+}
+
+const appConfig: AppConfig = {
+  directives: [
+    // The component that will be pre-rendered
+    AppComponent
+  ],
+  providers: [
+    // What URL should Angular be treating the app as if navigating
+    provide(REQUEST_URL, { useValue: '/' })
+  ]
+}
+
+export function getBootloader() : Bootloader  {
+  return new Bootloader(bootloaderConfig);
+}
+
+export function serialize(bootloader: Bootloader, template: string) : string {
+  appConfig.template = template;
+  return bootloader.serializeApplication(appConfig);
+}
+```
+
+Then configure the plugin with the template you want to pre-render, the path
+to your prerender entry file, and the path to your app files: 
+
+```
+
+plugins: [
+  // (...)
+  new PrerenderWebpackPlugin({
+    templatePath: 'index.html',
+    configPath: path.resolve(__dirname, './src/prerender-entry-file.ts'),
+    appPath: path.resolve(__dirname, './src/') 
+  })
+]
+```
+
+Note: although this plugin does not have a dependency on `angular2-universal`,
+the configuration file does. Make sure to install it.
+
+

--- a/modules/webpack-prerender/package.json
+++ b/modules/webpack-prerender/package.json
@@ -8,7 +8,8 @@
   "contributors": [
     "Tobias Bosch <tbosch@google.com>",
     "PatrickJS <github@gdi2290.com>",
-    "Jeff Whelpley <jeff@gethuman.com>"
+    "Jeff Whelpley <jeff@gethuman.com>",
+    "Filipe Silva <filipematossilva@gmail.com>"
   ],
   "scripts": {
     "remove-modules": "rimraf node_modules/angular2-universal-preview node_modules/angular2-universal node_modules/angular2-express-engine node_modules/preboot node_modules/angular2-hapi-engine node_modules/angular2-universal-polyfills",
@@ -25,24 +26,8 @@
     "url": "https://github.com/angular/universal/issues"
   },
   "devDependencies": {
-    "@angular/common": "2.0.0-rc.3",
-    "@angular/compiler": "2.0.0-rc.3",
-    "@angular/core": "2.0.0-rc.3",
-    "@angular/http": "2.0.0-rc.3",
-    "@angular/platform-browser": "2.0.0-rc.3",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.3",
-    "@angular/platform-server": "2.0.0-rc.3",
-    "@angular/router-deprecated": "2.0.0-rc.2",
-    "preboot": ">=2.1.2",
-    "angular2-universal": "file:../universal",
-    "rimraf": "^2.5.1",
-    "rxjs": "5.0.0-beta.6",
-    "zone.js": "~0.6.12",
     "typescript": "^1.8.9"
   },
   "dependencies": {
-  },
-  "peerDependencies": {
-    "angular2-universal": "^0.104.2"
   }
 }

--- a/modules/webpack-prerender/src/prerender.ts
+++ b/modules/webpack-prerender/src/prerender.ts
@@ -1,37 +1,53 @@
-import {Bootloader, BootloaderConfig, AppConfig} from 'angular2-universal';
-
-export interface IWebpackPrerender {
+interface IWebpackPrerender {
   templatePath: string;
-  bootloaderConfig: BootloaderConfig;
-  appConfig: AppConfig;
+  configPath: string;
+  appPath: string;
 }
 
 export class Angular2Prerender {
 
-  private bootloader: Bootloader;
+  private bootloader: any;
+  private cachedTemplate: string
 
   constructor(private options: IWebpackPrerender) {
     // maintain your platform instance
-    this.bootloader = new Bootloader(this.options.bootloaderConfig);
+    this.bootloader = require(this.options.configPath).getBootloader();
   }
 
   apply(compiler) {
     compiler.plugin('emit', (compilation, callback) => {
       if (compilation.assets.hasOwnProperty(this.options.templatePath)) {
-        this.bootloader.serializeApplication({
-          // or provide template in config.template
-          template: compilation.assets[this.options.templatePath].source(),
-          directives: this.options.appConfig.directives,
-          providers: this.options.appConfig.providers
-        })
-        .then(html => {
-          compilation.assets[this.options.templatePath] = {
-            source: () => html,
-            size: () => html.length
-          };
-          callback();
-        });
+        // we need to cache the template file to be able to re-serialize it
+        // even when it is not being emitted
+        this.cachedTemplate = compilation.assets[this.options.templatePath].source();
+      }
+
+      if (this.cachedTemplate) {
+        this.decacheAppFiles();
+        require(this.options.configPath).serialize(this.bootloader, this.cachedTemplate)
+          .then((html) => {
+            compilation.assets[this.options.templatePath] = {
+              source: () => html,
+              size: () => html.length
+            };
+            callback();
+          });
+      } else {
+        callback();
       }
     });
+  }
+
+  decacheAppFiles() {
+    // delete all app files from cache, but keep libs
+    // this is needed so that the config file can reimport up to date
+    // versions of the app files
+    delete require.cache[this.options.configPath];
+    Object.keys(require.cache)
+      .filter(key => key.startsWith(this.options.appPath))
+      .forEach(function (key) {
+        // console.log('===', key);
+        delete require.cache[key];
+      });
   }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] preboot
- [ ] universal-preview
- [ ] universal
- [x] webpack-prerender

* **What kind of change does this PR introduce?**
This PR decouples the prerender config from the webpack plugin.


* **What is the current behavior?**
Currently both behaviours are coupled, which can cause problems when including the plugin in tool-like projects that manipulate other projects. The two projects can have different `@angular/x` and `angular2-universal` dependencies, which would cause type errors on providers due to different type references.

Additionally, node require cache for app files is also deleted so that serialize can render an up to date version of the app.

* **What is the new behavior (if this is a feature change)?**
The config file exports the functions that the plugin needs to alter the prerendered template, but the dependencies are decoupled.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, instructions are included in the README.md file.


* **Other information**:

