### PR TITLE
bug(package): Remove typings from postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
     "tbosch",
     "bnjjj"
   ],
-  "scripts": {
-    "postinstall": "typings install"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/universal"


### PR DESCRIPTION
Causes error when `npm i` since typings.json isn't here anymore.