### PR TITLE
feat(universal): Allow for configuring if preboot complete() is called automatically (immediatelly) or manually (asynchronously)

### DIFF
--- a/modules/universal/src/browser/universal-module.ts
+++ b/modules/universal/src/browser/universal-module.ts
@@ -42,6 +42,7 @@ export class OpaqueToken {
 const SharedStylesHost: any = __platform_browser_private__.SharedStylesHost;
 
 export const UNIVERSAL_CACHE = new OpaqueToken('UNIVERSAL_CACHE');
+export const AUTO_PREBOOT = new OpaqueToken('AUTO_PREBOOT');
 
 @NgModule({
   imports: [
@@ -77,15 +78,22 @@ export const UNIVERSAL_CACHE = new OpaqueToken('UNIVERSAL_CACHE');
       deps: []
     },
     {
+      provide: AUTO_PREBOOT,
+      useValue: true
+    },
+    {
       multi: true,
       provide: APP_BOOTSTRAP_LISTENER,
-      useValue: () => {
-        let _win: any = window;
-        if (_win && prebootClient) {
-          setTimeout(() => prebootClient().complete());
-        }
-      }
-    }
+      useFactory: (autoPreboot: boolean) => {
+        return () => {
+          let _win: any = window;
+          if (_win && prebootClient && autoPreboot) {
+            setTimeout(() => prebootClient().complete());
+          }
+        };
+      },
+      deps: [ AUTO_PREBOOT ],
+    },
   ]
 })
 export class UniversalModule {
@@ -101,10 +109,18 @@ export class UniversalModule {
     });
   }
   static withConfig(_config: any = {}): {ngModule: UniversalModule, providers: any[]} {
+    const providers = [];
+
+    if (typeof _config.autoPreboot === 'boolean') {
+      providers.push({
+        provide: AUTO_PREBOOT,
+        useValue: _config.autoPreboot,
+      });
+    }
+
     return {
       ngModule: UniversalModule,
-      providers: [
-      ]
+      providers: providers,
     };
   }
 }

--- a/modules/universal/src/node/proxy-document.ts
+++ b/modules/universal/src/node/proxy-document.ts
@@ -136,6 +136,7 @@ export function createGlobalProxy() {
     }
   });
 
+  return document;
 }
 
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] universal-next
- [x] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
preboot complete() is called immediately upon client bootstrap, wether you want it to be or not


* **What is the new behavior (if this is a feature change)?**
Allows a configuration to override the automatic prebooting. This is especially useful is you have to do anything asynchronous before preboot complete runs, such as fetching data.

Usage is
```ts
imports: [
  UniversalModule.withConfig({ autoPreboot: false }), // default behavior is still `true`
]
```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

Open to any feedback on other ways to implement this feature and if good where to add tests and docs. Thanks!

…