### PR TITLE
fix(platform-node): Remove memory leak

### DIFF
--- a/modules/platform-node/node-platform.ts
+++ b/modules/platform-node/node-platform.ts
@@ -118,7 +118,7 @@ function s4() {
               /*implements PlatformRef*/
 export class NodePlatform  {
   static _noop = () => {};
-  static _cache = new Map<any, any>();
+  static _cache = new WeakMap<any, any>();
   get platformRef() {
     return this._platformRef;
   }
@@ -332,7 +332,7 @@ export class NodePlatform  {
         let prebootCode = null;
         // TODO(gdi2290): hide cache in (ngPreboot|UniversalPreboot)
         let prebootConfig = null;
-        let key = (typeof preboot === 'object') && JSON.stringify(preboot) || null;
+        let key = (typeof preboot === 'object') && preboot || null;
         let prebootEl = null;
         let el = null;
         let lastRef = null;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] universal-next
- [x] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes a memory leak


* **What is the current behavior?** (You can also link to an open issue here)
If you run servers in production, NgModules are generated per request and cached indefinitely, leading to a serious memory leak that will eventually floor your servers and you'll have to restart them constantly (up to every 15 minutes!)


* **What is the new behavior (if this is a feature change)?**
Use WeakMap instead of Map to ensure if all references are lost to a cache key the value is garbage collected


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

