### PR TITLE
fix(gulpfile): ngc cross-platform fix

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -58,7 +58,7 @@ gulp.task('build:no-clean', build);
 
 function build() {
   return new Promise((resolve, reject) => {
-    child_process.exec('node_modules/.bin/ngc', (err, stdout, stderr) => {
+    child_process.exec('npm run ngc', (err, stdout, stderr) => {
       if (err) {
         reject(err);
         return;

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -44,7 +44,7 @@ gulp.task('test', ['build'], (done) => {
 
 gulp.task('_test', () => {
   // Gulp Jasmine had weird behavior where it would run 0 specs on subsequent runs
-  child_process.spawnSync(`./node_modules/.bin/jasmine`, [], {stdio: 'inherit'});
+  child_process.spawnSync('npm run jasmine', [], {stdio: 'inherit'});
 });
 
 gulp.task('build', ['clean'], build);

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "npm": ">= 3"
   },
   "scripts": {
+    "ngc": "ngc",
     "test": "gulp test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "scripts": {
     "ngc": "ngc",
+    "jasmine": "jasmine",
     "test": "gulp test"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #608

'ngc' is an unknown internal/external command. 

Cross-platform fix to get
Windows `gulp` working by running ngc command through npm scripts.
