### PR TITLE
refactor(universal): --noImplicitAny support

### DIFF
--- a/build-utils.ts
+++ b/build-utils.ts
@@ -42,7 +42,7 @@ export function getRootDependencies(rootPackage: PackageLike, publishedModuleNam
     }), {}));
 }
 
-export function buildTs(files, compilerOptions: ts.CompilerOptions) {
+export function buildTs(files: string[], compilerOptions: ts.CompilerOptions) {
   let host = ts.createCompilerHost(compilerOptions);
   let program = ts.createProgram(files, compilerOptions, host);
   program.emit();
@@ -77,7 +77,7 @@ export function addMetadataToPackage(pkg: PackageLike, rootPackage: PackageLike)
   return Object.assign({}, pkg, {contributors, version, homepage, license, repository, bugs, config, engines});
 }
 
-export function stripSrcFromPath(path) {
+export function stripSrcFromPath(path: { dirname: string; }) {
   if (/\/src(\/.*|$)/.test(path.dirname)) {
     path.dirname = path.dirname.replace('/src', '');
   }

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -38,7 +38,7 @@ gulp.task('test:watch', ['test'], () => {
   });
 });
 
-gulp.task('test', ['build'], (done) => {
+gulp.task('test', ['build'], (done: () => void) => {
   runSequence('_test', done);
 });
 
@@ -96,7 +96,7 @@ gulp.task('rewrite_packages', () => {
   const publishedModuleNames = buildUtils.getPublishedModuleNames(allModules);
   const rootDependencies = buildUtils.getRootDependencies(rootPkg, publishedModuleNames);
   gulp.src('modules/**/package.json')
-    .pipe(jsonTransform((data, _file) => {
+    .pipe(jsonTransform((data: any, _file: any) => {
       if (data.main) {
         data.main = data.main.replace('src/', '').replace('.ts', '.js');
       }
@@ -122,7 +122,7 @@ gulp.task('clean', () => {
 gulp.task('pre-publish', ['build', 'rewrite_packages', 'changelog', 'copy_license', 'copy_files']);
 
 gulp.task('copy_license', () => {
-  return buildUtils.getAllModules().reduce((stream, mod: string) => {
+  return buildUtils.getAllModules().reduce((stream: any, mod: string) => {
     return stream.pipe(gulp.dest(`dist/${mod}`));
   }, gulp.src('LICENSE'));
 });

--- a/modules/grunt-prerender/tasks/prerender.ts
+++ b/modules/grunt-prerender/tasks/prerender.ts
@@ -1,9 +1,9 @@
 
 
 export class Prerender {
-  constructor(_options) {}
+  constructor(_options: any) {}
 
-  render(_file) {
+  render(_file: any) {
       return Promise.resolve('');
   }
 }
@@ -20,7 +20,7 @@ export class Prerender {
 // needs to be written like this otherwise Grunt will fail to load this task
 module.exports = class GruntPrerender {
 
-  constructor(grunt) {
+  constructor(grunt: any) {
 
     // Please see the Grunt documentation for more information regarding task
     // creation: http://gruntjs.com/creating-tasks

--- a/modules/gulp-prerender/src/prerender.ts
+++ b/modules/gulp-prerender/src/prerender.ts
@@ -1,6 +1,6 @@
 import * as through from 'through2';
 
-export function prerender(_options) {
+export function prerender(_options: any) {
   function transform(_file: any, _enc: string, _cb: Function) {
 
     return '';

--- a/modules/hapi-engine/src/engine.ts
+++ b/modules/hapi-engine/src/engine.ts
@@ -1,9 +1,9 @@
-export var HAPI_PLATFORM = null;
+export var HAPI_PLATFORM: any = null;
 
 export var HAPI_ANGULAR_APP = {
-  template: null,
-  directives: null,
-  providers: null
+  template: null as any,
+  directives: null as any,
+  providers: null as any
 };
 
 export function disposeHapiPlatform() {
@@ -31,15 +31,15 @@ export class hapiEngine {
     this.partials = {};
   }
 
-  registerHelper(_name, _helper) {
+  registerHelper(_name: any, _helper: any) {
 
   }
 
-  registerPartial(_name, _partial) {
+  registerPartial(_name: any, _partial: any) {
 
   }
 
-  compile(_template, _options, _next) {
+  compile(_template: any, _options: any, _next: any) {
     
   }
 

--- a/modules/platform-node/__private_imports__.ts
+++ b/modules/platform-node/__private_imports__.ts
@@ -57,6 +57,6 @@ export {
 
 }
 
-var __empty = null;
+var __empty: {} = null;
 
 export default __empty;

--- a/modules/platform-node/helper.ts
+++ b/modules/platform-node/helper.ts
@@ -210,5 +210,5 @@ export function arrayFlattenTree(children: any[], arr: any[]): any[] {
   return arr;
 }
 
-var __empty = null;
+var __empty: {} = null;
 export default __empty;

--- a/modules/platform-node/node-document.ts
+++ b/modules/platform-node/node-document.ts
@@ -10,7 +10,7 @@ const parse5: any = require('parse5');
 // const treeAdapter = parser.treeAdapter;
 const treeAdapter = parse5.treeAdapters.htmlparser2;
 
-export function isTag(tagName, node): boolean {
+export function isTag(tagName: string, node: any): boolean {
   return node.type === 'tag' && node.name === tagName;
 }
 
@@ -38,10 +38,10 @@ export function parseDocument (documentHtml: string): any {
   const doc = parser.parseFragment(documentHtml);
   */
 
-  let rootNode = undefined;
-  let bodyNode = undefined;
-  let headNode = undefined;
-  let titleNode = undefined;
+  let rootNode: any = undefined;
+  let bodyNode: any = undefined;
+  let headNode: any = undefined;
+  let titleNode: any = undefined;
 
   for (let i: number = 0; i < doc.childNodes.length; ++i) {
     const child = doc.childNodes[i];

--- a/modules/platform-node/node-http.ts
+++ b/modules/platform-node/node-http.ts
@@ -61,7 +61,7 @@ export class PreloadHttp extends Http {
     // this._activeNode = _rootNode;
 
   }
-  preload(_url, factory) {
+  preload(_url: any, factory: any) {
 
     var obs = new EventEmitter(false);
 
@@ -81,7 +81,7 @@ export class PreloadHttp extends Http {
 
     request
     .subscribe({
-        next: (response) => {
+        next: (response: any) => {
           // if (this.prime) {
           //   let headers = response.headers.toJSON();
           //   // TODO(gdi2290): fix Http to include the url
@@ -93,7 +93,7 @@ export class PreloadHttp extends Http {
           // }
           obs.next(response);
         },
-        error: (e) => {
+        error: (e: any) => {
           obs.error(e);
           this._async -= 1;
         },
@@ -184,8 +184,8 @@ export class NodeConnection implements XHRConnection {
     // needed for node xhrs
     _reqInfo.headers['user-agent'] = _reqInfo.headers['user-agent'] || 'Angular 2 Universal';
 
-    this.response = new Observable(responseObserver => {
-      let nodeReq;
+    this.response = new Observable((responseObserver: any) => {
+      let nodeReq: any;
       // ngZone.run(() => {
         // http or https
         let xhrHttp: any = http;
@@ -221,7 +221,7 @@ export class NodeConnection implements XHRConnection {
         });
       // });
 
-      let onError = (err) => {
+      let onError = (err: any) => {
         let responseOptions = new ResponseOptions({body: err, type: ResponseType.Error});
         if (isPresent(baseResponseOptions)) {
           responseOptions = baseResponseOptions.merge(responseOptions);
@@ -302,11 +302,11 @@ export class NodeJSONPConnection {
     _reqInfo.headers['user-agent'] = _reqInfo.headers['user-agent'] || 'Angular 2 Universal';
 
 
-    this.response = new Observable(responseObserver => {
-      let nodeReq;
+    this.response = new Observable((responseObserver: any) => {
+      let nodeReq: any;
       // http or https
       let xhrHttp: any = http;
-      function DONE(response) {
+      function DONE(response: any) {
         responseObserver.next(response);
         responseObserver.complete();
       }
@@ -325,13 +325,13 @@ export class NodeJSONPConnection {
         let url = res.url;
 
         res.on('end', () => {
-          var responseJson;
+          var responseJson: any;
           try {
             if (body.indexOf('JSONP_CALLBACK') === -1) {
               throw new Error('Http request ' + req.url + ' did not return the response with JSONP_CALLBACK()')
             }
             var responseFactory = new Function('JSONP_CALLBACK', body);
-            responseFactory(json => {
+            responseFactory((json: any) => {
               responseJson = json;
             });
           } catch (e) {
@@ -352,7 +352,7 @@ export class NodeJSONPConnection {
         });
       });
 
-      function onError (err) {
+      function onError (err: any) {
         let responseOptions = new ResponseOptions({body: err, type: ResponseType.Error});
         if (isPresent(baseResponseOptions)) {
           responseOptions = baseResponseOptions.merge(responseOptions);
@@ -422,7 +422,7 @@ export class NodeHttpModule {
     return NodeHttpModule.withConfig(config);
   }
   static withConfig(config: any = {}) {
-    var providers = [];
+    var providers: any[] = [];
     if (config.baseUrl) {
       providers.push({ provide: APP_BASE_HREF, useValue: config.baseUrl });
     }
@@ -448,7 +448,7 @@ export class NodeJsonpModule {
     return NodeJsonpModule.withConfig(config);
   }
   static withConfig(config: any = {}) {
-    var providers = [];
+    var providers: any[] = [];
     if (config.baseUrl) {
       providers.push({ provide: APP_BASE_HREF, useValue: config.baseUrl });
     }

--- a/modules/platform-node/node-location.ts
+++ b/modules/platform-node/node-location.ts
@@ -116,7 +116,7 @@ export class NodePlatformLocation extends PlatformLocation {
     // this.pushState(null, null, joinWithSlash(this._baseUrl, requestUrl));
     this.pushState(null, null, requestUrl);
   }
-  updateUrl(originUrl, baseUrl = '/') {
+  updateUrl(originUrl: string, baseUrl = '/') {
     this._originUrl = originUrl;
     this._baseUrl = baseUrl || '/';
   }
@@ -148,8 +148,8 @@ export class NodePlatformLocation extends PlatformLocation {
     this._updateLocation();
   }
 
-  onPopState(fn): void { this._popStateListeners.push(fn); }
-  onHashChange(_fn): void { /*TODO*/}
+  onPopState(fn: Function): void { this._popStateListeners.push(fn); }
+  onHashChange(_fn: any): void { /*TODO*/}
 
   back(): void {
     if (this._stackIndex === 0) {

--- a/modules/platform-node/node-platform.ts
+++ b/modules/platform-node/node-platform.ts
@@ -40,6 +40,7 @@ import {
   PlatformRef,
   NgModuleRef,
   NgZone,
+  Compiler,
   CompilerFactory,
   TestabilityRegistry
 } from '@angular/core';
@@ -104,7 +105,7 @@ export function removePlatformRef() {
 export function getPlatformRef(): PlatformRef {
   return __PLATFORM_REF;
 }
-export function setPlatformRef(platformRef) {
+export function setPlatformRef(platformRef: PlatformRef) {
   __PLATFORM_REF = platformRef;
 }
 // End platform Reference
@@ -123,12 +124,12 @@ export class NodePlatform  {
   }
   constructor(private _platformRef: PlatformRef) {
   }
-  cacheModuleFactory<T>(moduleType, compilerOptions?: any): Promise<NgModuleRef<T>> {
+  cacheModuleFactory<T>(moduleType: any, compilerOptions?: any): Promise<NgModuleRef<T>> {
     if (NodePlatform._cache.has(moduleType)) {
       return Promise.resolve(NodePlatform._cache.get(moduleType));
     }
     const compilerFactory: CompilerFactory = this._platformRef.injector.get(CompilerFactory);
-    var compiler;
+    var compiler: Compiler;
     if (compilerOptions) {
       compiler = compilerFactory.createCompiler(
       compilerOptions instanceof Array ? compilerOptions : [compilerOptions]);
@@ -188,10 +189,10 @@ export class NodePlatform  {
     // TODO(gdi2290): refactor to ZoneLocalStore
     var _map = new Map<any, any>();
     var _store = {
-      set(key, value, defaultValue?: any) {
+      set(key: any, value: any, defaultValue?: any) {
         _map.set(key, (value !== undefined) ? value : defaultValue);
       },
-      get(key, defaultValue?: any) {
+      get(key: any, defaultValue?: any) {
         return _map.has(key) ? _map.get(key) : defaultValue;
       },
       clear() {
@@ -201,7 +202,7 @@ export class NodePlatform  {
       }
     };
 
-    function errorHandler(_err, store, modRef, _currentIndex, _currentArray) {
+    function errorHandler(_err: any, store: any, modRef: any, _currentIndex: any, _currentArray: any) {
       var document = '';
       try {
         document = store.get('DOCUMENT');
@@ -258,8 +259,8 @@ export class NodePlatform  {
         universalOnInit();
 
         // lifecycle hooks
-        function outsideNg(compRef, ngZone, http, jsonp) {
-          function checkStable(done, ref) {
+        function outsideNg(compRef: any, ngZone: any, http: any, jsonp: any) {
+          function checkStable(done: any, ref: any) {
             ngZone.runOutsideAngular(() => {
               setTimeout(function stable() {
                 if (cancelHandler()) { return done(ref); }
@@ -325,16 +326,16 @@ export class NodePlatform  {
         let DOM = store.get('DOM');
         let DOCUMENT = store.get('DOCUMENT');
         let appRef: ApplicationRef = store.get('ApplicationRef');
-        let selectorsList = (<any>moduleRef).bootstrapFactories.map((factory) => factory.selector);
-        let bodyList = DOCUMENT.body.children.filter(el => Boolean(el.tagName)).map(el => el.tagName.toLowerCase()).join(',');
+        let selectorsList = (<any>moduleRef).bootstrapFactories.map((factory: any) => factory.selector);
+        let bodyList = DOCUMENT.body.children.filter((el: any) => Boolean(el.tagName)).map((el: any) => el.tagName.toLowerCase()).join(',');
         let components = appRef.components;
-        let prebootCode = null;
+        let prebootCode: any = null;
         // TODO(gdi2290): hide cache in (ngPreboot|UniversalPreboot)
-        let prebootConfig = null;
+        let prebootConfig: any = null;
         let key = (typeof preboot === 'object') && preboot || null;
-        let prebootEl = null;
-        let el = null;
-        let lastRef = null;
+        let prebootEl: any = null;
+        let el: any = null;
+        let lastRef: any = null;
         try {
           if (key && NodePlatform._cache.has(key)) {
             prebootEl = NodePlatform._cache.get(key).prebootEl;
@@ -350,7 +351,7 @@ export class NodePlatform  {
               prebootConfig.appRoot = selectorsList;
             }
             if (!selectorsList) {
-              selectorsList = (<any>moduleRef).bootstrapFactories.map((factory) => factory.selector);
+              selectorsList = (<any>moduleRef).bootstrapFactories.map((factory: any) => factory.selector);
             }
             config.time && console.time('id: ' + config.id + ' preboot insert dom: ');
             prebootCode = parseFragment('' +
@@ -365,7 +366,7 @@ export class NodePlatform  {
           }
 
           lastRef = {cmp: null, strIndex: -1, index: -1};
-          selectorsList.forEach((select, i) => {
+          selectorsList.forEach((select: any, i: number) => {
             let lastValue = bodyList.indexOf(select);
              if (lastValue >= lastRef.strIndex) {
                lastRef.strIndex = lastValue;
@@ -411,8 +412,8 @@ export class NodePlatform  {
         let DOM = store.get('DOM');
         let UNIVERSAL_CACHE = store.get('UNIVERSAL_CACHE');
         let document = store.get('DOCUMENT');
-        let script = null;
-        let el = null;
+        let script: any = null;
+        let el: any = null;
 
         // TODO(gdi2290): move and find a better way to inject script
         try {
@@ -450,9 +451,9 @@ export class NodePlatform  {
         let document = store.get('DOCUMENT');
         let appId = store.get('NODE_APP_ID');
         let appRef = store.get('ApplicationRef');
-        let html = null;
-        let destroyApp = null;
-        let destroyModule = null;
+        let html: any = null;
+        let destroyApp: any = null;
+        let destroyModule: any = null;
 
         html = serializeDocument(document).replace(/%cmp%/g, appId);
         universalOnRendered(html);
@@ -492,12 +493,12 @@ export class NodePlatform  {
   get injector(): Injector {
     return this.platformRef.injector;
   }
-  bootstrapModule<T>(moduleType, compilerOptions?: any): Promise<NgModuleRef<T>> {
+  bootstrapModule<T>(moduleType: any, compilerOptions?: any): Promise<NgModuleRef<T>> {
     if (NodePlatform._cache.has(moduleType)) {
       return this.platformRef.bootstrapModuleFactory(NodePlatform._cache.get(moduleType));
     }
     const compilerFactory: CompilerFactory = this._platformRef.injector.get(CompilerFactory);
-    var compiler;
+    var compiler: Compiler;
     if (compilerOptions) {
       compiler = compilerFactory.createCompiler(
       compilerOptions instanceof Array ? compilerOptions : [compilerOptions]);
@@ -510,7 +511,7 @@ export class NodePlatform  {
           return this.platformRef.bootstrapModuleFactory(moduleFactory);
         });
   }
-  bootstrapModuleFactory<T>(moduleFactory): Promise<NgModuleRef<T>> {
+  bootstrapModuleFactory<T>(moduleFactory: any): Promise<NgModuleRef<T>> {
     return this.platformRef.bootstrapModuleFactory(moduleFactory);
   }
 
@@ -545,13 +546,13 @@ export class NodePlatform  {
  * the event loop and better management of refernces in task. This also allows for ZoneLocalStore.
  * We can also introduce sagas or serverless
  */
-function asyncPromiseSeries(store, modRef, errorHandler, cancelHandler, config, middleware, _timer = 1) {
+function asyncPromiseSeries(store: any, modRef: any, errorHandler: any, cancelHandler: any, config: any, middleware: any, _timer = 1) {
   let errorCalled = false;
   config.time && console.time('id: ' + config.id + ' asyncPromiseSeries: ');
-  return middleware.reduce(function reduceAsyncPromiseSeries (promise, cb, currentIndex, currentArray) {
+  return middleware.reduce(function reduceAsyncPromiseSeries (promise: any, cb: any, currentIndex: any, currentArray: any) {
     // skip the rest of the promise middleware
     if (errorCalled || cancelHandler()) { return promise; }
-    return promise.then(function reduceAsyncPromiseSeriesChain (ref) {
+    return promise.then(function reduceAsyncPromiseSeriesChain (ref: any) {
       // skip the rest of the promise middleware
       if (errorCalled || cancelHandler()) { return ref; }
       return new Promise(function reduceAsyncPromiseSeriesPromiseChain(resolve, reject) {
@@ -564,11 +565,11 @@ function asyncPromiseSeries(store, modRef, errorHandler, cancelHandler, config, 
           }
         }, 0);
       });
-    }).catch(err => {
+    }).catch((err: any) => {
       errorCalled = true;
       return errorHandler(err, store, modRef, currentIndex, currentArray);
     });
-  }, Promise.resolve(modRef)).then((val) => {
+  }, Promise.resolve(modRef)).then((val: any) => {
     config.time && console.timeEnd('id: ' + config.id + ' asyncPromiseSeries: ');
     if (cancelHandler()) {
       return errorHandler(null, store, modRef, null, null);
@@ -644,7 +645,7 @@ export class NodeDomEventsPlugin {
     // we need to ensure that events are created in the fake document created for the current app
     var document = this.manager.getDocument();
     var zone = this.manager.getZone();
-    var element; // = getDOM().getGlobalEventTargetWithDocument(target, window, document, document.body);
+    var element: any; // = getDOM().getGlobalEventTargetWithDocument(target, window, document, document.body);
     switch (target) {
       case 'window':
         element = document._window;
@@ -664,20 +665,20 @@ export class NodeDomEventsPlugin {
 }
 
 
-export function _APP_BASE_HREF(_zone) {
+export function _APP_BASE_HREF(_zone: any) {
   return Zone.current.get('baseUrl');
 }
 
-export function _REQUEST_URL(_zone) {
+export function _REQUEST_URL(_zone: any) {
   return Zone.current.get('requestUrl');
 }
 
-export function _ORIGIN_URL(_zone) {
+export function _ORIGIN_URL(_zone: any) {
   return Zone.current.get('originUrl');
 }
 
 export class MockTestabilityRegistry extends TestabilityRegistry {
-  registerApplication() {
+  registerApplication(): any {
     return null;
   }
 }

--- a/modules/platform-node/node-renderer.ts
+++ b/modules/platform-node/node-renderer.ts
@@ -60,7 +60,7 @@ export class NodeDomRootRenderer implements RootRenderer {
 
 }
 
-export const ATTRIBUTES = {
+export const ATTRIBUTES: { [name: string]: string[]; } = {
   textarea: [
     'autocapitalize',
     'autocomplete',
@@ -224,7 +224,7 @@ export const ATTRIBUTES = {
 };
 
 // TODO(gdi2290): provide better whitelist above to alias setting props as attrs
-export const IGNORE_ATTRIBUTES = {
+export const IGNORE_ATTRIBUTES: { [key: string]: boolean; } = {
   'innerHTML': true,
   'hidden' : true
 };
@@ -448,7 +448,7 @@ export class NodeDomRenderer extends DomRenderer {
     return el;
   }
 
-  _isObject(val) {
+  _isObject(val: any) {
     if (val === null) {
       return false;
     }
@@ -520,7 +520,7 @@ export class NodeDomRenderer extends DomRenderer {
     return super.invokeElementMethod(location, methodName, args);
   }
 
-  _setDisabledAttribute(renderElement, _propertyName, propertyValue) {
+  _setDisabledAttribute(renderElement: any, _propertyName: any, propertyValue: any) {
     if (isPresent(propertyValue)) {
       if (propertyValue === true || propertyValue.toString() !== 'false') {
         return super.setElementAttribute(renderElement, 'disabled', 'disabled');
@@ -528,7 +528,7 @@ export class NodeDomRenderer extends DomRenderer {
     }
   }
 
-  _setCheckedAttribute(renderElement, _propertyName, propertyValue) {
+  _setCheckedAttribute(renderElement: any, _propertyName: any, propertyValue: any) {
     if (isPresent(propertyValue)) {
       if (propertyValue === true) {
         return super.setElementAttribute(renderElement, propertyValue, 'checked');
@@ -538,7 +538,7 @@ export class NodeDomRenderer extends DomRenderer {
     }
   }
 
-  _setOnOffAttribute(renderElement, propertyName, propertyValue) {
+  _setOnOffAttribute(renderElement: any, propertyName: any, propertyValue: any) {
     if (isPresent(propertyValue)) {
       if (propertyValue === true) {
         return super.setElementAttribute(renderElement, propertyValue, 'on');
@@ -549,7 +549,7 @@ export class NodeDomRenderer extends DomRenderer {
     return super.setElementAttribute(renderElement, propertyName, propertyValue);
 
   }
-  _setBooleanAttribute(renderElement, propertyName, propertyValue) {
+  _setBooleanAttribute(renderElement: any, propertyName: any, propertyValue: any) {
     if (isPresent(propertyValue) && propertyValue !== false) {
       if (propertyValue === true) {
         return super.setElementAttribute(renderElement, propertyName, '');

--- a/modules/platform-node/parse5.d.ts
+++ b/modules/platform-node/parse5.d.ts
@@ -10,7 +10,7 @@ declare module 'parse5' {
   export var serialize : Function;
   export var treeAdapters: any;
 
-  export var ParserStream;
-  export var SerializerStream;
-  export var SAXParser;
+  export var ParserStream: any;
+  export var SerializerStream: any;
+  export var SAXParser: any;
 }

--- a/modules/platform-node/tokens.ts
+++ b/modules/platform-node/tokens.ts
@@ -15,11 +15,11 @@ export function getUrlConfig() {
     { provide: APP_BASE_HREF, useValue: 'baseUrl' },
     { provide: REQUEST_URL, useValue: 'requestUrl' },
     { provide: ORIGIN_URL, useValue: 'originUrl' }
-  ]
+  ];
 }
 
 // @internal
-export function createUrlProviders(config) {
+export function createUrlProviders(config: any) {
   return getUrlConfig()
     .filter((provider) => (provider.useValue in config))
     .map((provider) => {

--- a/modules/universal/src/browser/universal-module.ts
+++ b/modules/universal/src/browser/universal-module.ts
@@ -16,7 +16,7 @@ import {
   __platform_browser_private__
 } from '@angular/platform-browser';
 
-var prebootClient;
+var prebootClient: any;
 try {
   prebootClient = require('preboot/__build/src/browser/preboot_browser');
   prebootClient = (prebootClient && prebootClient.prebootClient) || prebootClient;
@@ -47,7 +47,7 @@ export function universalCacheFactory() {
 export function appIdFactory() {
   let _win: any = window;
   let CACHE = _win.UNIVERSAL_CACHE || {};
-  let appId = null;
+  let appId: any = null;
   if (CACHE.APP_ID) {
     appId = CACHE.APP_ID;
   } else {
@@ -99,16 +99,16 @@ export class UniversalModule {
   constructor(@Inject(SharedStylesHost) sharedStylesHost: any) {
     const domStyles = document.head.querySelectorAll('style');
     const styles = Array.prototype.slice.call(domStyles)
-      .filter((style) => (style.innerText || style.textContent).indexOf('_ng') !== -1)
-      .map((style) => (style.innerText || style.textContent));
+      .filter((style: any) => (style.innerText || style.textContent).indexOf('_ng') !== -1)
+      .map((style: any) => (style.innerText || style.textContent));
 
-    styles.forEach(style => {
+    styles.forEach((style: any) => {
       sharedStylesHost._stylesSet.add(style);
       sharedStylesHost._styles.push(style);
     });
   }
   static withConfig(_config: any = {}): {ngModule: UniversalModule, providers: any[]} {
-    const providers = [];
+    const providers: any[] = [];
 
     if (typeof _config.autoPreboot === 'boolean') {
       providers.push({

--- a/modules/universal/src/common/index.ts
+++ b/modules/universal/src/common/index.ts
@@ -7,7 +7,7 @@ declare var Zone: any;
 export const zoneProps = new WeakMap();
 
 export class ZoneStore {
-  zone;
+  zone: any;
   constructor(props = Object.create(null)) {
     let store = new Map();
     try {
@@ -27,14 +27,14 @@ export class ZoneStore {
     zoneProps.get(this).clear();
   }
 
-  setMap(obj) {
+  setMap(obj: any) {
     const props = zoneProps.get(this);
     for (let prop of obj) {
       props.set(prop, obj);
     }
   }
 
-  get(key) {
+  get(key: any) {
     const props = zoneProps.get(this);
 
     if (this.has(key)) {
@@ -42,7 +42,7 @@ export class ZoneStore {
     }
     return null;
   }
-  set(key, value) {
+  set(key: any, value: any) {
     const props = zoneProps.get(this);
     if (this.has(key)) {
       props.set(key, value);
@@ -50,7 +50,7 @@ export class ZoneStore {
     }
     return null;
   }
-  has(key) {
+  has(key: any) {
     const props = zoneProps.get(this);
     return props.has && props.has(key);
   }

--- a/modules/universal/src/node/proxy-document.ts
+++ b/modules/universal/src/node/proxy-document.ts
@@ -141,7 +141,7 @@ export function createGlobalProxy() {
 
 
 
-function querySelector(query) {
+function querySelector(query: any) {
   const DOM = getDOM();
   var parentElement = Zone.current.get('parentElement');
   var element = DOM.querySelector(parentElement, query);
@@ -152,7 +152,7 @@ function querySelector(query) {
   return new ProxyElement(zone);
 }
 
-function querySelectorAll(query) {
+function querySelectorAll(query: any) {
   const DOM = getDOM();
   var parentElement = Zone.current.get('parentElement');
   var element = DOM.querySelectorAll(parentElement, query);

--- a/modules/webpack-prerender/src/prerender.ts
+++ b/modules/webpack-prerender/src/prerender.ts
@@ -40,8 +40,8 @@ export class UniversalPrerender {
     // }
   }
 
-  apply(compiler) {
-    compiler.plugin('emit', (_compilation, _callback) => {
+  apply(compiler: any) {
+    compiler.plugin('emit', (_compilation: any, _callback: any) => {
       this.platformRef = this.platformRef || platformUniversalDynamic();
       this._options.document = this._options.document || _compilation.assets[this._options.documentPath].source();
       const zone = Zone.current.fork({
@@ -49,7 +49,7 @@ export class UniversalPrerender {
         properties: this._options
       });
       zone.run(() => (this.platformRef.serializeModule(this._options.ngModule, this._options))
-        .then((html) => {
+        .then((html: any) => {
           if (typeof html !== 'string' || this._options.cancel) {
             _compilation.assets[this._options.documentPath] = {
               source: () => this._options.document,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   	"target": "es5",
   	"module": "commonjs",
   	"declaration": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "noUnusedLocals": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   	"target": "es5",
   	"module": "commonjs",
   	"declaration": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noUnusedLocals": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "inlineSources": true,
     "rootDir": ".",
   	"outDir": "compiled/ngc",
-    "pretty": true,
+    "pretty": false,
     "stripInternal": false,
     "lib": ["es6", "dom"],
     "types": [


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] universal-next
- [X] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

improve ts files.
Now, angular2-platform-node (and preboot) are not compatible with --noImplicitAny options.
This is spread affect to user land tsconfig settings.
I want to use --noImplicitAny options in my project.

* **What is the current behavior?** (You can also link to an open issue here)

Users can't use --noImplicitAny with this package.

* **What is the new behavior (if this is a feature change)?**

We can use --noImplicitAny with this package!

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

maybe no

* **Other information**:

https://github.com/angular/preboot/pull/23