### PR TITLE
fix(polyfills): Remove reflect-metadata from the polyfills

### DIFF
--- a/modules/universal-polyfills/package.json
+++ b/modules/universal-polyfills/package.json
@@ -7,8 +7,7 @@
   "dependencies": {
     "ie-shim": "<INHERIT>",
     "es6-promise": "<INHERIT>",
-    "es6-shim": "<INHERIT>",
-    "reflect-metadata": "<INHERIT>"
+    "es6-shim": "<INHERIT>"
   },
   "peerDependencies": {
     "zone.js": "<INHERIT>"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
   * The need to manually require this module is part of the angular core documentation

* **What modules are related to this pull-request**
- [X] universal-polyfills

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
#604 


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

Change the polyfills to include reflect-metadata as a peer dependancy. If two modules import different versions of this module it will cause some very confusing errors. By including it as a peer npm will output a warning upon detecting a version mismatch and will only install the newer of the mismatched versions.

Fixes angular/universal#604