### PR TITLE
Fixed, sharedStylesHost._styles

### DIFF
--- a/modules/universal/src/browser/universal-module.ts
+++ b/modules/universal/src/browser/universal-module.ts
@@ -97,6 +97,7 @@ export function appBootstrapListenerFactory(autoPreboot: boolean) {
 })
 export class UniversalModule {
   constructor(@Inject(SharedStylesHost) sharedStylesHost: any) {
+    sharedStylesHost._styles = sharedStylesHost._styles || [];
     const domStyles = document.head.querySelectorAll('style');
     const styles = Array.prototype.slice.call(domStyles)
       .filter((style: any) => (style.innerText || style.textContent).indexOf('_ng') !== -1)


### PR DESCRIPTION
if there are no styles imported, then null object reference for sharedStylesHost._styles, 
Added a fix to check before and initialize if not already.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] universal-next
- [ ] universal
- [ ] webpack-prerender

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
