### PR TITLE
feat(hapi): add support for hapi engine

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,11 @@ npm run build:ng-express-engine
 cp modules/ng-express-engine/package.json dist/ng-express-engine/package.json
 cp modules/ng-express-engine/README.md dist/ng-express-engine/README.md
 
+npm run build:ng-hapi-engine
+
+cp modules/ng-hapi-engine/package.json dist/ng-hapi-engine/package.json
+cp modules/ng-hapi-engine/README.md dist/ng-hapi-engine/README.md
+
 npm run build:ng-aspnetcore-engine
 
 cp modules/ng-aspnetcore-engine/package.json dist/ng-aspnetcore-engine/package.json

--- a/modules/ng-hapi-engine/README.md
+++ b/modules/ng-hapi-engine/README.md
@@ -1,0 +1,91 @@
+# Angular Hapi Engine
+
+This is a Hapi Engine for running Angular Apps on the server for server side rendering.
+
+## Usage
+
+`npm install @nguniversal/hapi-engine --save`
+
+To use it, set the engine and then route requests to it
+
+```ts
+import { Base_Reply, Request, Server } from 'hapi';
+import { ngHapiEngine } from '@nguniversal/hapi-engine';
+
+const server = new Server();
+server.connection({
+  host: 'localhost',
+  port: 8000
+});
+
+// Set the engine
+const hapiEngine = ngHapiEngine({
+  bootstrap: ServerAppModule // Give it a module to bootstrap
+});
+
+server.route({
+  method: 'GET',
+  path: '/{path*}',
+  handler: (req: Request, reply: Base_Reply) => {
+    hapiEngine({
+      req
+    }).then(html => reply(html))
+      .then(err => reply(boom.wrap(err));
+  }
+});
+
+
+```
+
+## Extra Providers
+
+Extra Providers can be provided either on engine setup
+
+```ts
+const hapiEngine = ngHapiEngine({
+  bootstrap: ServerAppModule,
+  providers: [
+    ServerService
+  ]
+}));
+```
+
+## Advanced Usage
+
+### Request based Bootstrap
+
+The Bootstrap module as well as more providers can be passed on request
+
+```ts
+server.route({
+  method: 'GET',
+  path: '/{path*}',
+  handler: (req: Request, reply: Base_Reply) => {
+    hapiEngine({
+      bootstrap: OtherServerAppModule,
+      providers: [
+        OtherServerService
+      ],
+      req
+    }).then(html => reply(html))
+      .then(err => reply(boom.wrap(err));
+  }
+});
+```
+
+### Using the Request and Response
+
+The Request and Response objects are injected into the app via injection tokens.
+You can access them by @Inject
+
+```ts
+import { Request } from 'hapi';
+import { REQUEST } from '@nguniversal/hapi-engine/tokens';
+
+@Injectable()
+export class RequestService {
+  constructor(@Inject(REQUEST) private request: Request) {}
+}
+```
+
+If your app runs on the client side too, you will have to provide your own versions of these in the client app.

--- a/modules/ng-hapi-engine/index.ts
+++ b/modules/ng-hapi-engine/index.ts
@@ -1,0 +1,1 @@
+export { ngHapiEngine, NgSetupOptions, RenderOptions } from './src/main';

--- a/modules/ng-hapi-engine/package.json
+++ b/modules/ng-hapi-engine/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@nguniversal/hapi-engine",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "version": "1.0.0-beta.1",
+  "description": "Hapi Engine for running Server Angular Apps",
+  "homepage": "https://github.com/angular/universal",
+  "license": "MIT",
+  "contributors": [
+    "wesleycho"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/universal"
+  },
+  "bugs": {
+    "url": "https://github.com/angular/universal/issues"
+  },
+  "config": {
+    "engine-strict": true
+  },
+  "engines": {
+    "node": ">= 5.4.1 <= 7",
+    "npm": ">= 3"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rimraf dist"
+  },
+  "peerDependencies": {
+    "@angular/core": "^4.0.0",
+    "@angular/platform-server": "^4.0.0",
+    "hapi": "^16.1.1"
+  },
+  "devDependencies": {
+    "@angular/animations": "^4.0.0",
+    "@angular/common": "^4.0.0",
+    "@angular/compiler": "^4.0.0",
+    "@angular/core": "^4.0.0",
+    "@angular/platform-browser": "^4.0.0",
+    "@angular/platform-server": "^4.0.0",
+    "express": "^16.1.1",
+    "rimraf": "^2.6.1",
+    "rxjs": "^5.2.0",
+    "typescript": "^2.2.1",
+    "zone.js": "^0.8.4"
+  }
+}

--- a/modules/ng-hapi-engine/src/file-loader.ts
+++ b/modules/ng-hapi-engine/src/file-loader.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs';
+import { ResourceLoader } from '@angular/compiler';
+
+export class FileLoader implements ResourceLoader {
+  get(url: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      fs.readFile(url, (err: NodeJS.ErrnoException, buffer: Buffer) => {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve(buffer.toString());
+      });
+    });
+  }
+}

--- a/modules/ng-hapi-engine/src/main.ts
+++ b/modules/ng-hapi-engine/src/main.ts
@@ -1,0 +1,146 @@
+import * as fs from 'fs';
+import { Request } from 'hapi';
+
+import { Provider, NgModuleFactory, Type, CompilerFactory, Compiler } from '@angular/core';
+import { ResourceLoader } from '@angular/compiler';
+import { INITIAL_CONFIG, renderModuleFactory, platformDynamicServer } from '@angular/platform-server';
+
+import { FileLoader } from './file-loader';
+import { REQUEST, RESPONSE } from './tokens';
+
+/**
+ * These are the allowed options for the engine
+ */
+export interface NgSetupOptions {
+  bootstrap: Type<{}> | NgModuleFactory<{}>;
+  providers?: Provider[];
+}
+
+/**
+ * These are the allowed options for the render
+ */
+export interface RenderOptions extends NgSetupOptions {
+  req: Request;
+}
+
+/**
+ * This holds a cached version of each index used.
+ */
+const templateCache: { [key: string]: string } = {};
+
+/**
+ * Map of Module Factories
+ */
+const factoryCacheMap = new Map<Type<{}>, NgModuleFactory<{}>>();
+
+/**
+ * This is an express engine for handling Angular Applications
+ */
+export function ngHapiEngine(options: RenderOptions) {
+
+  const compilerFactory: CompilerFactory = platformDynamicServer().injector.get(CompilerFactory);
+  const compiler: Compiler = compilerFactory.createCompiler([
+    {
+      providers: [
+        { provide: ResourceLoader, useClass: FileLoader }
+      ]
+    }
+  ]);
+
+  if (options.req.raw.req.url === undefined) {
+    return Promise.reject(new Error('url is undefined'));
+  }
+
+  const filePath = <string> options.req.raw.req.url;
+
+  options.providers = options.providers || [];
+
+  return new Promise((resolve, reject) => {
+    const moduleOrFactory = options.bootstrap;
+
+    if (!moduleOrFactory) {
+      return reject(new Error('You must pass in a NgModule or NgModuleFactory to be bootstrapped'));
+    }
+
+    const extraProviders = (<Provider[]> options.providers).concat(
+      <Provider[]> options.providers,
+      getReqProviders(options.req),
+      [
+        {
+          provide: INITIAL_CONFIG,
+          useValue: {
+            document: getDocument(filePath),
+            url: filePath
+          }
+        }
+      ]);
+
+    getFactory(moduleOrFactory, compiler)
+      .then(factory => {
+        return renderModuleFactory(factory, {
+          extraProviders
+        });
+      })
+      .then((html: string) => {
+        resolve(html);
+      }, (err) => {
+        reject(err);
+      });
+  });
+}
+
+/**
+ * Get a factory from a bootstrapped module/ module factory
+ */
+function getFactory(
+  moduleOrFactory: Type<{}> | NgModuleFactory<{}>, compiler: Compiler
+): Promise<NgModuleFactory<{}>> {
+  return new Promise<NgModuleFactory<{}>>((resolve, reject) => {
+    // If module has been compiled AoT
+    if (moduleOrFactory instanceof NgModuleFactory) {
+      resolve(moduleOrFactory);
+      return;
+    } else {
+      let moduleFactory = factoryCacheMap.get(moduleOrFactory);
+
+      // If module factory is cached
+      if (moduleFactory) {
+        resolve(moduleFactory);
+        return;
+      }
+
+      // Compile the module and cache it
+      compiler.compileModuleAsync(moduleOrFactory)
+        .then((factory) => {
+          factoryCacheMap.set(moduleOrFactory, factory);
+          resolve(factory);
+        }, (err => {
+          reject(err);
+        }));
+    }
+  });
+}
+
+/**
+ * Get providers of the request and response
+ */
+function getReqProviders(req: Request): Provider[] {
+  const providers: Provider[] = [
+    {
+      provide: REQUEST,
+      useValue: req
+    }
+  ];
+  providers.push({
+    provide: RESPONSE,
+    useValue: req.raw.res
+  });
+  return providers;
+}
+
+/**
+ * Get the document at the file path
+ */
+function getDocument(filePath: string): string {
+  return templateCache[filePath] = templateCache[filePath] || fs.readFileSync(filePath).toString();
+}

--- a/modules/ng-hapi-engine/src/tokens.ts
+++ b/modules/ng-hapi-engine/src/tokens.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'hapi';
+import { InjectionToken } from '@angular/core';
+
+export const REQUEST = new InjectionToken<Request>('REQUEST');
+export const RESPONSE = new InjectionToken<Response>('RESPONSE');

--- a/modules/ng-hapi-engine/tokens.ts
+++ b/modules/ng-hapi-engine/tokens.ts
@@ -1,0 +1,1 @@
+export { RESPONSE, REQUEST } from './src/tokens';

--- a/modules/ng-hapi-engine/tsconfig.json
+++ b/modules/ng-hapi-engine/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/ng-hapi-engine"
+  },
+  "angularCompilerOptions": {
+    "genDir": "ngfactory"
+  },
+  "files": [
+    "index.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ngc": "ngc",
     "jasmine": "jasmine",
     "build:ng-express-engine": "ngc -p modules/ng-express-engine/tsconfig.json",
+    "build:ng-hapi-engine": "ngc -p modules/ng-hapi-engine/tsconfig.json",
     "build:ng-aspnetcore-engine": "ngc -p modules/ng-aspnetcore-engine/tsconfig.json",
     "build": "./build.sh",
     "test": "exit 0"
@@ -75,7 +76,9 @@
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-server": "^4.0.0",
     "@types/express": "^4.0.35",
+    "@types/hapi": "^16.1.2",
     "express": "^4.15.2",
+    "hapi": "^16.1.1",
     "rimraf": "^2.6.1",
     "rxjs": "^5.2.0",
     "typescript": "^2.2.1",

--- a/publish.sh
+++ b/publish.sh
@@ -5,4 +5,5 @@ set -x
 npm run build
 
 npm publish --access public dist/ng-express-engine
+npm publish --access public dist/ng-hapi-engine
 npm publish --access public dist/ng-aspnetcore-engine


### PR DESCRIPTION
- Add hapi engine support for Universal

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] Express Engine
- [x] Hapi Engine

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It adds a basic engine for running on a hapi server


* **What is the current behavior?** (You can also link to an open issue here)
Universal does not support hapi via engine #720


* **What is the new behavior (if this is a feature change)?**
This adds support for running Universal on a hapi server


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
This may be better potentially implemented as a plugin - I could rejig this if that is what is desired.