### PR TITLE
docs(express): fix up return values

### DIFF
--- a/modules/ng-express-engine/README.md
+++ b/modules/ng-express-engine/README.md
@@ -20,8 +20,10 @@ app.engine('html', ngExpressEngine({
 app.set('view engine', 'html');
 
 app.get('/**/*', (req: Request, res: Response) => {
-  req: req,
-  res: res
+  res.render('../dist/index', {
+    req,
+    res
+  });
 });
 ```
 
@@ -46,12 +48,14 @@ The Bootstrap module as well as more providers can be passed on request
 
 ```ts
 app.get('/**/*', (req: Request, res: Response) => {
-  req: req,
-  res: res,
-  bootstrap: OtherServerAppModule,
-  providers: [
-    OtherServerService
-  ]
+  res.render('../dist/index', {
+    req,
+    res,
+    bootstrap: OtherServerAppModule,
+    providers: [
+      OtherServerService
+    ]
+  });
 });
 ```
 
@@ -78,8 +82,10 @@ You can also use a custom callback to better handle your errors
 
 ```ts
 app.get('/**/*', (req: Request, res: Response) => {
-  req: req,
-  res: res
+  res.render('../dist/index', {
+    req,
+    res
+  });
 }, (err: Error, html: string) => {
   res.status(html ? 200 : 500).send(html || err.message);
 });


### PR DESCRIPTION
- Fix up syntax error for options that are intended to be returned
- Change to take advantage of object shorthand

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [x] Express Engine

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixing documentation of syntax errors


* **What is the current behavior?** (You can also link to an open issue here)
Currently the readme recommends using
```ts
(req: Request, res: Response) => {
  req: req,
  res: res
}
```
but this is a syntax error in Node.


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
