### PR TITLE
build(engines): extend tsconfigs off a base tsconfig

### DIFF
--- a/modules/ng-aspnetcore-engine/src/main.ts
+++ b/modules/ng-aspnetcore-engine/src/main.ts
@@ -14,8 +14,6 @@ export function ngAspnetCoreEngine(
   options: IEngineOptions
 ): Promise<{ html: string, globals: { styles: string, title: string, meta: string, transferData?: {}, [key: string]: any } }> {
 
-  options.providers = options.providers || [];
-
   const compilerFactory: CompilerFactory = platformDynamicServer().injector.get(CompilerFactory);
   const compiler: Compiler = compilerFactory.createCompiler([
     {
@@ -32,6 +30,8 @@ export function ngAspnetCoreEngine(
       if (!moduleOrFactory) {
         throw new Error('You must pass in a NgModule or NgModuleFactory to be bootstrapped');
       }
+
+      options.providers = options.providers || [];
 
       const extraProviders = options.providers.concat(
         options.providers,
@@ -69,7 +69,7 @@ export function ngAspnetCoreEngine(
               .subscribe(() => {
 
                 // Fire the TransferState Cache
-                const bootstrap = moduleRef.instance['ngOnBootstrap'];
+                const bootstrap = (<{ ngOnBootstrap?: Function }> moduleRef.instance).ngOnBootstrap;
                 bootstrap && bootstrap();
 
                 // The parse5 Document itself

--- a/modules/ng-aspnetcore-engine/tsconfig.json
+++ b/modules/ng-aspnetcore-engine/tsconfig.json
@@ -1,39 +1,12 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es6",
-    "module": "es2015",
-    "moduleResolution": "node",
-    "declaration": true,
-    "noImplicitAny": false,
-    "noUnusedLocals": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noUnusedParameters": true,
-    "removeComments": false,
-    "baseUrl": ".",
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "sourceMap": true,
-    "inlineSources": true,
-    "rootDir": ".",
-    "outDir": "../../dist/ng-aspnetcore-engine",
-    "lib": [
-      "dom",
-      "es6"
-    ],
-    "types": [
-      "node"
-    ]
+    "outDir": "../../dist/ng-aspnetcore-engine"
   },
   "angularCompilerOptions": {
     "genDir": "ngfactory"
   },
   "files": [
     "index.ts"
-  ],
-  "compileOnSave": false,
-  "buildOnSave": false,
-  "atom": {
-    "rewriteTsconfig": false
-  }
+  ]
 }

--- a/modules/ng-express-engine/src/main.ts
+++ b/modules/ng-express-engine/src/main.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { Request, Response, Send } from 'express';
+import { Request, Response } from 'express';
 
 import { Provider, NgModuleFactory, Type, CompilerFactory, Compiler } from '@angular/core';
 import { ResourceLoader } from '@angular/compiler';
@@ -39,8 +39,6 @@ const factoryCacheMap = new Map<Type<{}>, NgModuleFactory<{}>>();
  */
 export function ngExpressEngine(setupOptions: NgSetupOptions) {
 
-  setupOptions.providers = setupOptions.providers || [];
-
   const compilerFactory: CompilerFactory = platformDynamicServer().injector.get(CompilerFactory);
   const compiler: Compiler = compilerFactory.createCompiler([
     {
@@ -50,7 +48,7 @@ export function ngExpressEngine(setupOptions: NgSetupOptions) {
     }
   ]);
 
-  return function (filePath: string, options: RenderOptions, callback: Send) {
+  return function (filePath: string, options: RenderOptions, callback: (err?: Error | null, html?: string) => void) {
 
     options.providers = options.providers || [];
 
@@ -60,6 +58,8 @@ export function ngExpressEngine(setupOptions: NgSetupOptions) {
       if (!moduleOrFactory) {
         throw new Error('You must pass in a NgModule or NgModuleFactory to be bootstrapped');
       }
+
+      setupOptions.providers = setupOptions.providers || [];
 
       const extraProviders = setupOptions.providers.concat(
         options.providers,
@@ -126,7 +126,7 @@ function getFactory(
 /**
  * Get providers of the request and response
  */
-function getReqResProviders(req: Request, res: Response): Provider[] {
+function getReqResProviders(req: Request, res?: Response): Provider[] {
   const providers: Provider[] = [
     {
       provide: REQUEST,

--- a/modules/ng-express-engine/tsconfig.json
+++ b/modules/ng-express-engine/tsconfig.json
@@ -1,29 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "declaration": true,
-    "noImplicitAny": false,
-    "noUnusedLocals": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noUnusedParameters": true,
-    "removeComments": false,
-    "baseUrl": ".",
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "sourceMap": true,
-    "inlineSources": true,
-    "rootDir": ".",
-    "outDir": "../../dist/ng-express-engine",
-    "lib": [
-      "dom",
-      "es6"
-    ],
-    "types": [
-      "node"
-    ]
+    "outDir": "../../dist/ng-express-engine"
   },
   "angularCompilerOptions": {
     "genDir": "ngfactory"
@@ -31,10 +9,5 @@
   "files": [
     "index.ts",
     "tokens.ts"
-  ],
-  "compileOnSave": false,
-  "buildOnSave": false,
-  "atom": {
-    "rewriteTsconfig": false
-  }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "removeComments": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "sourceMap": true,
+    "lib": [
+      "dom",
+      "es6"
+    ],
+    "types": [
+      "node"
+    ]
+  },
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "atom": {
+    "rewriteTsconfig": false
+  }
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [x] Express Engine
- [x] .NET Engine

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

build / refactor

* **What is the current behavior?** (You can also link to an open issue here)

Currently everybody has their own tsconfig.

* **What is the new behavior (if this is a feature change)?**

Everybody can extend their tsconfig off of a main one

Also applied stricter typescript checks

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It should not

* **Other information**:
