### PR TITLE
chore(ci): add c++11 standard compliant compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,14 @@ notifications:
 env:
   global:
   - SAUCE_ACCESS_KEY=''
+  - CXX=g++-4.8
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 
 before_install:
   # Updating NPM to relevant version >= 3 on Node.JS LTS


### PR DESCRIPTION
- Add installation of C++11 standard compliant compiler to Travis CI build process

* **Please check if the PR fulfills these requirements**
```
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)
```

* **What modules are related to this pull-request**
```
- [ ] aspnetcore-engine
- [ ] express-engine
- [ ] hapi-engine
```

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
CI update

* **What is the current behavior?** (You can also link to an open issue here)
Travis CI posts a warning about building of native extensions - here is a sample snippet from a [build](https://travis-ci.org/angular/universal/jobs/241704388):
> Starting with io.js 3 and Node.js 4, building native extensions requires C++11-compatible compiler, which seems unavailable on this VM. Please read https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements.


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
