### PR TITLE
feat(ng-express-engine): add support for compiler providers

### DIFF
--- a/modules/express-engine/README.md
+++ b/modules/express-engine/README.md
@@ -40,6 +40,9 @@ app.engine('html', ngExpressEngine({
 }));
 ```
 
+If you need to use providers for the compiler (for example for i18n), you may want to
+use the `compilerProviders` option.
+
 ## Advanced Usage
 
 ### Request based Bootstrap

--- a/modules/express-engine/src/main.ts
+++ b/modules/express-engine/src/main.ts
@@ -13,6 +13,7 @@ import { REQUEST, RESPONSE } from './tokens';
  */
 export interface NgSetupOptions {
   bootstrap: Type<{}> | NgModuleFactory<{}>;
+  compilerProviders?: StaticProvider[];
   providers?: StaticProvider[];
 }
 
@@ -40,11 +41,18 @@ const factoryCacheMap = new Map<Type<{}>, NgModuleFactory<{}>>();
 export function ngExpressEngine(setupOptions: NgSetupOptions) {
 
   const compilerFactory: CompilerFactory = platformDynamicServer().injector.get(CompilerFactory);
+
+  let compilerProviders: StaticProvider[] = [
+    { provide: ResourceLoader, useClass: FileLoader, deps: [] },
+  ];
+
+  if (setupOptions.compilerProviders) {
+    compilerProviders.push(...setupOptions.compilerProviders);
+  }
+
   const compiler: Compiler = compilerFactory.createCompiler([
     {
-      providers: [
-        { provide: ResourceLoader, useClass: FileLoader, deps: [] }
-      ]
+      providers: compilerProviders
     }
   ]);
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
```
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
```

* **What modules are related to this pull-request**
```
- [ ] aspnetcore-engine
- [x] express-engine
- [ ] hapi-engine
```

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds the `compilerProviders` setup option to to add custom providers to
the compiler used by the express engine, for example for i18n.

* **What is the current behavior?** (You can also link to an open issue here)

It is not possible use compiler providers, see #733.

* **What is the new behavior (if this is a feature change)?**

It is now possible to use the `compilerProviders` setup option to use compiler providers.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

I've been using this patch without any issue for a few projects but I'd like someone to check if it is OK.