### PR TITLE
fix(express-engine): change provider assignable type from Provider to…

### DIFF
--- a/modules/ng-express-engine/src/main.ts
+++ b/modules/ng-express-engine/src/main.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { Request, Response } from 'express';
 
-import { Provider, NgModuleFactory, Type, CompilerFactory, Compiler } from '@angular/core';
+import { Provider, StaticProvider, NgModuleFactory, Type, CompilerFactory, Compiler } from '@angular/core';
 import { ResourceLoader } from '@angular/compiler';
 import { INITIAL_CONFIG, renderModuleFactory, platformDynamicServer } from '@angular/platform-server';
 
@@ -13,7 +13,7 @@ import { REQUEST, RESPONSE } from './tokens';
  */
 export interface NgSetupOptions {
   bootstrap: Type<{}> | NgModuleFactory<{}>;
-  providers?: Provider[];
+  providers?: StaticProvider[];
 }
 
 /**


### PR DESCRIPTION
I'm submitting a ...
```
- [x] bug report
- [ ] feature request
```

```
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```
Tested in combination of pull request of #774


* **What modules are related to this pull-request**
```
- [ ] aspnetcore-engine
- [x] express-engine
- [ ] hapi-engine
```

* **What is the current behavior?**
express-engine gives error while compiling the typescript for the server.

* **What is the new behavior (if this is a feature change)?**
Adds compatibility with the latest version of Angular (v5.0.0-beta.4)

* **Does this PR introduce a breaking change?** 
No

* **Please tell us about your environment:**
Angular version: 5.0.0-beta.3