### PR TITLE
fix(module-loader): change type of provideModuleMap to StaticProvider

### DIFF
--- a/modules/module-map-ngfactory-loader/src/module-map-loader.module.ts
+++ b/modules/module-map-ngfactory-loader/src/module-map-loader.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, NgModuleFactoryLoader, ModuleWithProviders, Provider } from '@angular/core';
+import { NgModule, NgModuleFactoryLoader, ModuleWithProviders, StaticProvider } from '@angular/core';
 
 import { ModuleMapNgFactoryLoader, ModuleMap, MODULE_MAP } from './module-map-ngfactory-loader';
 
@@ -7,7 +7,7 @@ import { ModuleMapNgFactoryLoader, ModuleMap, MODULE_MAP } from './module-map-ng
  *
  * @param {ModuleMap} moduleMap Map to use as a value for MODULE_MAP
  */
-export function provideModuleMap(moduleMap: ModuleMap): Provider {
+export function provideModuleMap(moduleMap: ModuleMap): StaticProvider {
   return {
     provide: MODULE_MAP,
     useValue: moduleMap


### PR DESCRIPTION
- Changes return type of provideModuleMap to StaticProvider to
  allow for compatibility with angular v5

* **Please check if the PR fulfills these requirements**
```
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

* **What modules are related to this pull-request**
```
- [ ] aspnetcore-engine
- [ ] express-engine
- [ ] hapi-engine
- [x] module-loader
```

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Return type of provideModuleMap is Provider

* **What is the new behavior (if this is a feature change)?**

Return type of provideModuleMap is StaticProvider

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Since master requires angular v5, no breaking change. 

* **Other information**:

Should only be merged to the 5.x branch

cc @Toxicable @vikerman 
