### PR TITLE
docs(hapi): fix parens in example code

### DIFF
--- a/modules/hapi-engine/README.md
+++ b/modules/hapi-engine/README.md
@@ -30,7 +30,7 @@ server.route({
     hapiEngine({
       req
     }).then(html => reply(html))
-      .then(err => reply(boom.wrap(err));
+      .then(err => reply(boom.wrap(err)));
   }
 });
 
@@ -47,7 +47,7 @@ const hapiEngine = ngHapiEngine({
   providers: [
     ServerService
   ]
-}));
+});
 ```
 
 ## Advanced Usage
@@ -68,7 +68,7 @@ server.route({
       ],
       req
     }).then(html => reply(html))
-      .then(err => reply(boom.wrap(err));
+      .then(err => reply(boom.wrap(err)));
   }
 });
 ```


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
```
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

* **What modules are related to this pull-request**
```
- [ ] aspnetcore-engine
- [ ] express-engine
- [x] hapi-engine
```

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs update

* **What is the current behavior?** (You can also link to an open issue here)
Some example code in hapi README are ill-formed; parenthesis is not balanced.


* **What is the new behavior (if this is a feature change)?**
fix the example code by adding/removing parens


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
