### PR TITLE
docs(universal): Expand TransferHttpCacheModule installation steps

### DIFF
--- a/modules/common/README.md
+++ b/modules/common/README.md
@@ -18,9 +18,7 @@ on the server and store the response in the `TransferState` key-value store. Thi
 
 ### Usage
 
-To use the `TransferHttpCacheModule` just install it as part of the top-level App module.
-
-That's it!
+To use the `TransferHttpCacheModule`, first install it as part of the top-level App module.
 
 ```ts
 import {TransferHttpCacheModule} from '@nguniversal/common';
@@ -33,4 +31,45 @@ import {TransferHttpCacheModule} from '@nguniversal/common';
   bootstrap: [MyApp]
 })
 export class AppBrowserModule() {}
+```
+Then, import `ServerTransferStateModule` in your Server module.
+
+```ts
+import { NgModule } from "@angular/core";
+import {
+  ServerModule,
+  ServerTransferStateModule
+} from "@angular/platform-server";
+
+import { AppModule } from "./app.module";
+import { AppComponent } from "./app.component";
+
+@NgModule({
+  imports: [
+    AppModule,
+    ServerModule,
+    ServerTransferStateModule
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppServerModule {}
+
+```
+Finally, in `main.ts` change this:
+
+```ts
+...
+
+platformBrowserDynamic().bootstrapModule(AppBrowserModule);
+```
+To this: 
+
+```ts
+...
+
+document.addEventListener("DOMContentLoaded", () => {
+  platformBrowserDynamic()
+    .bootstrapModule(AppBrowserModule)
+    .catch(err => console.log(err));
+});
 ```


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
```
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
```

* **What modules are related to this pull-request**
```
- [ ] aspnetcore-engine
- [ ] express-engine
- [ ] hapi-engine
```

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update for TransferHttpCacheModule.

* **What is the current behavior?** (You can also link to an open issue here)
I couldn't get TransferHttpCacheModule to work by only installing it in my top-level App module, as the documentation suggests. 


* **What is the new behavior (if this is a feature change)?**
Improved documentation. I had to do add two other steps for the module to work: import ServerTransferStateModule in Server module and wrap bootstrapModule call under an event listener. This blog post pointed me in the right direction: https://medium.com/@evertonrobertoauler/angular-5-universal-with-transfer-state-using-angular-cli-19fe1e1d352c


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

Steps tested successfully with Angular 5