### PR TITLE
fix(aspnet): remove duplicate options providers registration

### DIFF
--- a/modules/aspnetcore-engine/src/main.ts
+++ b/modules/aspnetcore-engine/src/main.ts
@@ -95,19 +95,18 @@ export function ngAspnetCoreEngine(
       options.providers = options.providers || [];
 
       const extraProviders = options.providers.concat(
-        ...options.providers,
-          [{
-            provide: ORIGIN_URL,
-            useValue: options.request.origin
-          }, {
-            provide: REQUEST,
-            useValue: options.request.data.request
-          }, {
-            provide: BEFORE_APP_SERIALIZED,
-            useFactory: beforeAppSerialized, multi: true, deps: [ DOCUMENT ]
-          }
-        ]
-      );
+        [{
+          provide: ORIGIN_URL,
+          useValue: options.request.origin
+        }, {
+          provide: REQUEST,
+          useValue: options.request.data.request
+        }, {
+          provide: BEFORE_APP_SERIALIZED,
+          useFactory: beforeAppSerialized, multi: true, deps: [ DOCUMENT ]
+        }
+      ]
+    );
 
       getFactory(moduleOrFactory, compiler)
         .then(factory => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
```
- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

* **What modules are related to this pull-request**
```
- [x] aspnetcore-engine
- [ ] express-engine
- [ ] hapi-engine
```

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
Options providers are registered as duplicates


* **What is the new behavior (if this is a feature change)?**
Removed duplicates option providers


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
