### PR TITLE
chore(ci): clean up old config from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,9 @@ node_js:
   - '6'
   - '7'
   - '8'
+  - '9'
 
-cache:
-  directories:
-    - node_modules
-    - typings
+cache: yarn
 
 notifications:
   webhooks:
@@ -19,24 +17,8 @@ notifications:
   slack:
     secure: EP4MzZ8JMyNQJ4S3cd5LEPWSMjC7ZRdzt3veelDiOeorJ6GwZfCDHncR+4BahDzQAuqyE/yNpZqaLbwRWloDi15qIUsm09vgl/1IyNky1Sqc6lEknhzIXpWSalo4/T9ZP8w870EoDvM/UO+LCV99R3wS8Nm9o99eLoWVb2HIUu0=
 
-env:
-  global:
-  - SAUCE_ACCESS_KEY=''
-  - CXX=g++-4.8
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
-
-before_install:
-  # Updating NPM to relevant version >= 3 on Node.JS LTS
-  - npm i -g npm@^3
-
 before_script:
-  - npm install
+  - yarn install --frozen-lockfile
 
 script:
   - ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,28 +1,28 @@
-rm -rf dist
+#!/bin/bash
 
-set -x
+set -Eeuo pipefail
 
-npm run build:common || exit 1
+npm run build:common
 
 cp modules/common/package.json dist/common/package.json
 cp modules/common/README.md dist/common/README.md
 
-npm run build:express-engine || exit 1
+npm run build:express-engine
 
 cp modules/express-engine/package.json dist/express-engine/package.json
 cp modules/express-engine/README.md dist/express-engine/README.md
 
-npm run build:aspnetcore-engine || exit 1
+npm run build:aspnetcore-engine
 
 cp modules/aspnetcore-engine/package.json dist/aspnetcore-engine/package.json
 cp modules/aspnetcore-engine/README.md dist/aspnetcore-engine/README.md
 
-npm run build:hapi-engine || exit 1
+npm run build:hapi-engine
 
 cp modules/hapi-engine/package.json dist/hapi-engine/package.json
 cp modules/hapi-engine/README.md dist/hapi-engine/README.md
 
-npm run build:module-map-ngfactory-loader || exit 1
+npm run build:module-map-ngfactory-loader
 
 cp modules/module-map-ngfactory-loader/package.json dist/module-map-ngfactory-loader/package.json
 cp modules/module-map-ngfactory-loader/README.md dist/module-map-ngfactory-loader/README.md


### PR DESCRIPTION
cleaning up some old config from travis

I wasn't sure what these were, let me know if they're important
>env:
  global:
  - SAUCE_ACCESS_KEY=''
  - CXX=g++-4.8

cuts off about 2 min on build time