### PR TITLE
feat(modules): pass in absolute URL as default for view rendering

### DIFF
--- a/modules/aspnetcore-engine/src/main.ts
+++ b/modules/aspnetcore-engine/src/main.ts
@@ -128,7 +128,7 @@ export function ngAspnetCoreEngine(options: IEngineOptions): Promise<IEngineRend
         .then(factory => {
           return renderModuleFactory(factory, {
             document: options.document || options.appSelector,
-            url: options.url || options.request.url,
+            url: options.url || options.request.absoluteUrl,
             extraProviders: extraProviders
           });
         })

--- a/modules/express-engine/src/main.ts
+++ b/modules/express-engine/src/main.ts
@@ -76,6 +76,7 @@ export function ngExpressEngine(setupOptions: NgSetupOptions) {
 
       setupOptions.providers = setupOptions.providers || [];
 
+      const req = options.req;
       const extraProviders = setupOptions.providers.concat(
         options.providers,
         getReqResProviders(options.req, options.res),
@@ -84,7 +85,7 @@ export function ngExpressEngine(setupOptions: NgSetupOptions) {
             provide: INITIAL_CONFIG,
             useValue: {
               document: options.document || getDocument(filePath),
-              url: options.url || options.req.originalUrl
+              url: options.url || req.protocol + '://' + req.get('host') + req.originalUrl
             }
           }
         ]);

--- a/modules/express-engine/src/main.ts
+++ b/modules/express-engine/src/main.ts
@@ -85,7 +85,7 @@ export function ngExpressEngine(setupOptions: NgSetupOptions) {
             provide: INITIAL_CONFIG,
             useValue: {
               document: options.document || getDocument(filePath),
-              url: options.url || req.protocol + '://' + req.get('host') + req.originalUrl
+              url: options.url || req.protocol + '://' + (req.get('host') || '') + req.originalUrl
             }
           }
         ]);

--- a/modules/hapi-engine/src/main.ts
+++ b/modules/hapi-engine/src/main.ts
@@ -52,6 +52,7 @@ const factoryCacheMap = new Map<Type<{}>, NgModuleFactory<{}>>();
  */
 export function ngHapiEngine(options: RenderOptions) {
 
+  const req = options.req;
   const compilerFactory: CompilerFactory = platformDynamicServer().injector.get(CompilerFactory);
   const compiler: Compiler = compilerFactory.createCompiler([
     {
@@ -61,11 +62,12 @@ export function ngHapiEngine(options: RenderOptions) {
     }
   ]);
 
-  if (options.req.raw.req.url === undefined) {
+  if (req.raw.req.url === undefined) {
     return Promise.reject(new Error('url is undefined'));
   }
 
-  const filePath = <string> options.req.raw.req.url;
+  const filePath = <string> req.raw.req.url;
+  const url = `${req.connection.info.protocol}://${req.info.host}${req.url.path}`;
 
   options.providers = options.providers || [];
 
@@ -84,7 +86,7 @@ export function ngHapiEngine(options: RenderOptions) {
           provide: INITIAL_CONFIG,
           useValue: {
             document: options.document || getDocument(filePath),
-            url: options.url || filePath
+            url: options.url || url
           }
         }
       ]);

--- a/modules/hapi-engine/src/main.ts
+++ b/modules/hapi-engine/src/main.ts
@@ -66,8 +66,9 @@ export function ngHapiEngine(options: RenderOptions) {
     return Promise.reject(new Error('url is undefined'));
   }
 
+  const rawUrl = req.url;
   const filePath = <string> req.raw.req.url;
-  const url = `${req.connection.info.protocol}://${req.info.host}${req.url.path}`;
+  const url = `${rawUrl.protocol || ''}://${rawUrl.host || ''}${rawUrl.path || ''}`;
 
   options.providers = options.providers || [];
 


### PR DESCRIPTION
* Add the absolute URL to view generation to allow for access through
  the document's native location object
* Future PR will allow user to override the default url

NOTE: This will act as a precursor to correct absolute path resolution for `HttpClient`