### PR TITLE
 docs: reduce uneeded info in issue/pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,17 @@
-**Note: for support questions, please use one of [these channels][Channels]**. This repository's issues are reserved 
-for feature requests and bug reports. Also, **Preboot has moved** [here][preboot] - please make preboot-related issues 
-there.
+<!--
+PLEASE HELP US PROCESS GITHUB ISSUES FASTER BY PROVIDING THE FOLLOWING INFORMATION.
 
-* **I'm submitting a ...**
+ISSUES MISSING IMPORTANT INFORMATION MAY BE CLOSED WITHOUT INVESTIGATION.
+-->
+
+## I'm submitting a ...
 ```
-- [ ] bug report
+- [ ] bug report <!-- Please search GitHub for a similar issue or PR before submitting -->
 - [ ] feature request
-- [ ] support request => Please do not submit support request here, see note at the top of this template.
+- [ ] Support request => Please do not submit support request here, instead see https://github.com/angular/universal/blob/master/CONTRIBUTING.md#question
 ```
 
-* **What modules are related to this Issue?**
+## What modules are related to this Issue?
 ```
 - [ ] aspnetcore-engine
 - [ ] common
@@ -18,39 +20,25 @@ there.
 - [ ] module-map-ngfactory-loader
 ```
 
-* **Do you want to request a *feature* or report a *bug*?**
+## Current behavior?
 
+## Expected behavior?
 
+## Minimal reproduction with instructions
 
-* **What is the current behavior?**
+## Environment:
+**@nguniversal versions**
+  - aspnetcore-engine: 
+  - common:
+  - express-engine:
+  - hapi-engine:
+  - module-map-ngfactory-loader:
+```
+<!--
+Output from: `ng --version`.
+If nothing, output from: `node --version` and `npm --version`.
+  Windows (7/8/10). Linux (incl. distribution). macOS (El Capitan? Sierra?)
+-->
+```
 
-
-
-* **If the current behavior is a bug**, please provide the steps to reproduce and if possible a minimal demo of the 
-problem by creating a github repo.
-
-
-
-* **What is the expected behavior?**
-
-
-
-* **What is the motivation / use case for changing the behavior?**
-
-
-
-* **Please tell us about your environment:**
-
-- Angular version: X.Y.Z
-- Browser: [all | Chrome XX | Firefox XX | IE XX | Safari XX ]
-- Language: [all | TypeScript X.X | ES6/7 | ES5 ]
-- OS:  [all | Mac OS X | Windows | Linux ]
-- Platform: [all | NodeJS | Java | PHP | .NETCore | Ruby]
-
-
-
-* **Other information** (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us 
-to have context, eg. stackoverflow, gitter, etc)
-
-[Channels]: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#question
-[preboot]: https://github.com/angular/preboot
+## Other information (optional)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,43 @@
-* **Please check if the PR fulfills these requirements**
-```
-- [ ] The commit message follows [our guidelines](https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit-message-format)
+## PR Checklist
+Please check if your PR fulfills the following requirements:
+
+- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
+
+
+## PR Type
+What kind of change does this PR introduce?
+
+<!-- Please check the one that applies to this PR using "x". -->
+```
+[ ] Bugfix
+[ ] Feature
+[ ] Code style update (formatting, local variables)
+[ ] Refactoring (no functional changes, no api changes)
+[ ] Build related changes
+[ ] CI related changes
+[ ] Documentation content changes
+[ ] angular.io application / infrastructure changes
+[ ] Other... Please describe:
 ```
 
-* **What modules are related to this pull-request**
+## What is the current behavior?
+<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
+
+Issue Number: N/A
+
+
+## What is the new behavior?
+
+
+## Does this PR introduce a breaking change?
 ```
-- [ ] aspnetcore-engine
-- [ ] common
-- [ ] express-engine
-- [ ] hapi-engine
-- [ ] module-map-ngfactory-loader
+[ ] Yes
+[ ] No
 ```
 
-* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
 
 
-* **What is the current behavior?** (You can also link to an open issue here)
-
-
-
-* **What is the new behavior (if this is a feature change)?**
-
-
-
-* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
-
-
-* **Other information**:
+## Other information


### PR DESCRIPTION
condenses the info neeed in PR / Issue templates down to just what we actually need
Also makes it more readable