### PR TITLE
refactor(common): reduce CommonEngine api

### DIFF
--- a/modules/common/src/common-engine/engine.ts
+++ b/modules/common/src/common-engine/engine.ts
@@ -38,23 +38,23 @@ export class CommonEngine {
    * Render an HTML document for a specific URL with specified
    * render options
    */
-  render(filePath: string, opts: RenderOptions): Promise<string> {
+  async render(opts: RenderOptions): Promise<string> {
+    // if opts.document dosen't exist then opts.documentFilePath must
+    const doc = opts.document || await this.getDocument(opts!.documentFilePath as string);
     const extraProviders = [
       ...(opts.providers || []),
       ...(this.providers || []),
-      [
-        {
-          provide: INITIAL_CONFIG,
-          useValue: {
-            document: opts.document || this.getDocument(filePath),
-            url: opts.url
-          }
+      {
+        provide: INITIAL_CONFIG,
+        useValue: {
+          document: doc,
+          url: opts.url
         }
-      ]
+      }
     ];
 
-    return this.getFactory()
-      .then(factory => renderModuleFactory(factory, {extraProviders}));
+    const factory = await this.getFactory();
+    return renderModuleFactory(factory, {extraProviders});
   }
 
   /** Return the factory for a given engine instance */

--- a/modules/common/src/common-engine/interfaces.ts
+++ b/modules/common/src/common-engine/interfaces.ts
@@ -7,16 +7,11 @@
  */
 import {NgModuleFactory, StaticProvider, Type} from '@angular/core';
 
-/** These are the allowed options for the engine */
-export interface NgSetupOptions {
+/** These are the allowed options for the render */
+export interface RenderOptions {
   bootstrap: Type<{}> | NgModuleFactory<{}>;
   providers?: StaticProvider[];
-}
-
-/** These are the allowed options for the render */
-export interface RenderOptions extends NgSetupOptions {
-  req: any;
-  res?: any;
-  document?: string;
   url?: string;
+  document?: string;
+  documentFilePath?: string;
 }

--- a/modules/common/tokens/index.ts
+++ b/modules/common/tokens/index.ts
@@ -5,5 +5,4 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-export { FileLoader as ɵFileLoader, CommonEngine as ɵCommonEngine,
-   RenderOptions as ɵRenderOptions } from './src/common-engine';
+export * from './public_api';


### PR DESCRIPTION
- exports the private tokens from Common Engine
- exports less of the private api in Common Engine 