### PR TITLE
feat(common): TransferHttpCache now respects url params

### DIFF
--- a/modules/common/engine/private_api.ts
+++ b/modules/common/engine/private_api.ts
@@ -5,5 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
 export { FileLoader as ɵFileLoader, CommonEngine as ɵCommonEngine,
-   RenderOptions as ɵRenderOptions } from './src/index';
+  RenderOptions as ɵRenderOptions } from './src/index';

--- a/modules/common/private_api.ts
+++ b/modules/common/private_api.ts
@@ -5,6 +5,4 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-export { TransferHttpCacheModule } from './src/transfer_http';
-export { StateTransferInitializerModule } from './src/state-transfer-initializer/module';
-export * from './private_api';
+export { TransferHttpCacheInterceptor as ɵTransferHttpCacheInterceptor } from './src/transfer_http';

--- a/modules/common/spec/transfer_http.spec.ts
+++ b/modules/common/spec/transfer_http.spec.ts
@@ -1,0 +1,40 @@
+import { ɵTransferHttpCacheInterceptor as TransferHttpCacheInterceptor } from '@nguniversal/common';
+import { of } from 'rxjs';
+import { HttpParams } from '@angular/common/http';
+
+function mockAppRef(): any {
+  return {
+    isStable: of(true)
+  };
+}
+
+function mockTransferState(): any {
+  return {
+    store: {}
+  };
+}
+
+describe('TransferHttp', () => {
+  describe('keys', () => {
+    it('should encode url params', () => {
+      const interceptor = new TransferHttpCacheInterceptor(mockAppRef(), mockTransferState());
+      const key = interceptor['makeCacheKey']('GET', 'https://google.com/api',
+       new HttpParams().append('foo', 'bar'));
+      expect(key).toEqual('G.https://google.com/api?foo=bar');
+    });
+    it('should sort the keys by unicode points', () => {
+      const interceptor = new TransferHttpCacheInterceptor(mockAppRef(), mockTransferState());
+      const key = interceptor['makeCacheKey']('GET', 'https://google.com/api',
+        new HttpParams().append('b', 'foo').append('a', 'bar'));
+      expect(key).toEqual('G.https://google.com/api?a=bar&b=foo');
+    });
+    it('should make equal keys if order of params changes', () => {
+      const interceptor = new TransferHttpCacheInterceptor(mockAppRef(), mockTransferState());
+      const key1 = interceptor['makeCacheKey']('GET', 'https://google.com/api',
+        new HttpParams().append('a', 'bar').append('b', 'foo'));
+      const key2 = interceptor['makeCacheKey']('GET', 'https://google.com/api',
+        new HttpParams().append('b', 'foo').append('a', 'bar'));
+      expect(key1).toEqual(key2);
+    });
+  });
+});

--- a/modules/common/src/transfer_http.ts
+++ b/modules/common/src/transfer_http.ts
@@ -12,10 +12,12 @@ import {
   HttpHeaders,
   HttpInterceptor,
   HttpRequest,
-  HttpResponse
+  HttpResponse,
+  HttpParams
 } from '@angular/common/http';
 import {ApplicationRef, Injectable, NgModule} from '@angular/core';
-import {BrowserTransferStateModule, TransferState, makeStateKey} from '@angular/platform-browser';
+import {BrowserTransferStateModule, TransferState,
+   makeStateKey, StateKey} from '@angular/platform-browser';
 import {Observable, of as observableOf} from 'rxjs';
 import {tap, take, filter} from 'rxjs/operators';
 
@@ -41,8 +43,15 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
   private isCacheActive = true;
 
   private invalidateCacheEntry(url: string) {
-    this.transferState.remove(makeStateKey<TransferHttpResponse>('G.' + url));
-    this.transferState.remove(makeStateKey<TransferHttpResponse>('H.' + url));
+    Object.keys(this.transferState['store'])
+      .forEach(key => key.includes(url) ? this.transferState.remove(makeStateKey(key)) : null);
+  }
+
+  private makeCacheKey(method: string, url: string, params: HttpParams): StateKey<string> {
+    // make the params encoded same as a url so it's easy to identify
+    const encodedParams = params.keys().sort().map(k => `${k}=${params.get(k)}`).join('&');
+    const key = (method === 'GET' ? 'G.' : 'H.') + url + '?' + encodedParams;
+    return makeStateKey<TransferHttpResponse>(key);
   }
 
   constructor(appRef: ApplicationRef, private transferState: TransferState) {
@@ -68,8 +77,7 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
       return next.handle(req);
     }
 
-    const key = (req.method === 'GET' ? 'G.' : 'H.') + req.url;
-    const storeKey = makeStateKey<TransferHttpResponse>(key);
+    const storeKey = this.makeCacheKey(req.method, req.url, req.params);
 
     if (this.transferState.hasKey(storeKey)) {
       // Request found in cache. Respond using it.

--- a/modules/common/src/transfer_http.ts
+++ b/modules/common/src/transfer_http.ts
@@ -16,8 +16,12 @@ import {
   HttpParams
 } from '@angular/common/http';
 import {ApplicationRef, Injectable, NgModule} from '@angular/core';
-import {BrowserTransferStateModule, TransferState,
-   makeStateKey, StateKey} from '@angular/platform-browser';
+import {
+  BrowserTransferStateModule,
+  TransferState,
+  makeStateKey,
+  StateKey
+} from '@angular/platform-browser';
 import {Observable, of as observableOf} from 'rxjs';
 import {tap, take, filter} from 'rxjs/operators';
 


### PR DESCRIPTION
Based on the work in https://github.com/angular/universal/pull/987

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?
TransferHttpCache does not respect url params  
Issue Number: https://github.com/angular/universal/issues/927


## What is the new behavior?
Now respects params 

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information
Technically this is a breaking change since 
before:
/my/url?key=value
/my/url
Both of these would override each others values in the cache
But now they'd have their own cache
