### PR TITLE
fix(common): remove internal monicker for FileLoader

### DIFF
--- a/modules/common/src/common-engine/file-loader.ts
+++ b/modules/common/src/common-engine/file-loader.ts
@@ -8,10 +8,7 @@
 import * as fs from 'fs';
 import { ResourceLoader } from '@angular/compiler';
 
-/**
- * ResourceLoader implementation for loading files
- * @internal
- */
+/** ResourceLoader implementation for loading files */
 export class FileLoader implements ResourceLoader {
   get(url: string): Promise<string> {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
* this causes issues with bundling, and is not needed since the export is already "private"