### PR TITLE
build: publish only ng_package-s tagged with 'release'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - checkout:
           <<: *post_checkout
 
-      - run: bazel run @yarn//:yarn
+      - run: yarn install --frozen-lockfile
       - run: scripts/build-modules-dist.sh
 
       # Save the npm packages from //modules/... for other workflow jobs to read

--- a/modules/aspnetcore-engine/BUILD.bazel
+++ b/modules/aspnetcore-engine/BUILD.bazel
@@ -27,6 +27,7 @@ ng_package(
         ":aspnetcore-engine",
         "//modules/aspnetcore-engine/tokens",
     ],
+    tags = ["release"],
 )
 
 ts_library(

--- a/modules/aspnetcore-engine/BUILD.bazel
+++ b/modules/aspnetcore-engine/BUILD.bazel
@@ -23,11 +23,11 @@ ng_package(
     ],
     entry_point = "modules/aspnetcore-engine/index.js",
     readme_md = ":README.md",
+    tags = ["release"],
     deps = [
         ":aspnetcore-engine",
         "//modules/aspnetcore-engine/tokens",
     ],
-    tags = ["release"],
 )
 
 ts_library(

--- a/modules/common/BUILD.bazel
+++ b/modules/common/BUILD.bazel
@@ -21,12 +21,12 @@ ng_package(
     srcs = [":package.json"],
     entry_point = "modules/common/index.js",
     readme_md = ":README.md",
+    tags = ["release"],
     deps = [
         ":common",
         "//modules/common/engine",
         "//modules/common/tokens",
     ],
-    tags = ["release"],
 )
 
 ts_library(

--- a/modules/common/BUILD.bazel
+++ b/modules/common/BUILD.bazel
@@ -26,6 +26,7 @@ ng_package(
         "//modules/common/engine",
         "//modules/common/tokens",
     ],
+    tags = ["release"],
 )
 
 ts_library(

--- a/modules/express-engine/BUILD.bazel
+++ b/modules/express-engine/BUILD.bazel
@@ -27,6 +27,7 @@ ng_package(
         ":express-engine",
         "//modules/express-engine/tokens",
     ],
+    tags = ["release"],
 )
 
 ts_library(

--- a/modules/express-engine/BUILD.bazel
+++ b/modules/express-engine/BUILD.bazel
@@ -23,11 +23,11 @@ ng_package(
     entry_point = "modules/express-engine/index.js",
     packages = ["//modules/express-engine/schematics:npm_package"],
     readme_md = ":README.md",
+    tags = ["release"],
     deps = [
         ":express-engine",
         "//modules/express-engine/tokens",
     ],
-    tags = ["release"],
 )
 
 ts_library(

--- a/modules/hapi-engine/BUILD.bazel
+++ b/modules/hapi-engine/BUILD.bazel
@@ -22,11 +22,11 @@ ng_package(
     ],
     entry_point = "modules/hapi-engine/index.js",
     readme_md = ":README.md",
+    tags = ["release"],
     deps = [
         ":hapi-engine",
         "//modules/hapi-engine/tokens",
     ],
-    tags = ["release"],
 )
 
 ts_library(

--- a/modules/hapi-engine/BUILD.bazel
+++ b/modules/hapi-engine/BUILD.bazel
@@ -26,6 +26,7 @@ ng_package(
         ":hapi-engine",
         "//modules/hapi-engine/tokens",
     ],
+    tags = ["release"],
 )
 
 ts_library(

--- a/modules/module-map-ngfactory-loader/BUILD.bazel
+++ b/modules/module-map-ngfactory-loader/BUILD.bazel
@@ -18,8 +18,8 @@ ng_package(
     srcs = [":package.json"],
     entry_point = "modules/module-map-ngfactory-loader/index.js",
     readme_md = ":README.md",
-    deps = [":module-map-ngfactory-loader"],
     tags = ["release"],
+    deps = [":module-map-ngfactory-loader"],
 )
 
 ts_library(

--- a/modules/module-map-ngfactory-loader/BUILD.bazel
+++ b/modules/module-map-ngfactory-loader/BUILD.bazel
@@ -19,6 +19,7 @@ ng_package(
     entry_point = "modules/module-map-ngfactory-loader/index.js",
     readme_md = ":README.md",
     deps = [":module-map-ngfactory-loader"],
+    tags = ["release"],
 )
 
 ts_library(

--- a/modules/socket-engine/BUILD.bazel
+++ b/modules/socket-engine/BUILD.bazel
@@ -27,6 +27,7 @@ ng_package(
         ":socket-engine",
         "//modules/common",
     ],
+    tags = ["release"],
 )
 
 ts_library(

--- a/modules/socket-engine/BUILD.bazel
+++ b/modules/socket-engine/BUILD.bazel
@@ -23,11 +23,11 @@ ng_package(
     ],
     entry_point = "modules/socket-engine/index.js",
     readme_md = ":README.md",
+    tags = ["release"],
     deps = [
         ":socket-engine",
         "//modules/common",
     ],
-    tags = ["release"],
 )
 
 ts_library(

--- a/publish-next.sh
+++ b/publish-next.sh
@@ -8,7 +8,7 @@ set -u -e -o pipefail
 # Publish them to npm (tagged next)
 
 # query for all npm packages to be released as part of the framework release
-NPM_PACKAGE_LABELS=`bazel query --output=label 'kind(".*_package", //modules/...)'`
+NPM_PACKAGE_LABELS=`bazel query --output=label 'attr("tags", "\[.*release.*\]", //modules/...) intersect kind(".*_package", //modules/...)'`
 # build all npm packages in parallel
 bazel build $NPM_PACKAGE_LABELS
 # publish all packages in sequence to make it easier to spot any errors or warnings

--- a/publish.sh
+++ b/publish.sh
@@ -8,7 +8,7 @@ set -u -e -o pipefail
 # Publish them to npm (tagged next)
 
 # query for all npm packages to be released as part of the framework release
-NPM_PACKAGE_LABELS=`bazel query --output=label 'kind(".*_package", //modules/...)'`
+NPM_PACKAGE_LABELS=`bazel query --output=label 'attr("tags", "\[.*release.*\]", //modules/...) intersect kind(".*_package", //modules/...)'`
 # build all npm packages in parallel
 bazel build $NPM_PACKAGE_LABELS
 # publish all packages in sequence to make it easier to spot any errors or warnings


### PR DESCRIPTION
Otherwise schematics ng_package was getting picked up for npm publish and would fail. The schematics package is a deps of the main module package and not meant for publishing.