### PR TITLE
fix(common): Update transfer_http cache to not invalidate after mutating calls

### DIFF
--- a/modules/common/src/transfer_http.ts
+++ b/modules/common/src/transfer_http.ts
@@ -70,10 +70,10 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
   }
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    // Stop using the cache if there is a mutating call.
+    // Skip the cache entirely for calls that seek to mutate data.
     if (req.method !== 'GET' && req.method !== 'HEAD') {
-      this.isCacheActive = false;
       this.invalidateCacheEntry(req.url);
+      return next.handle(req);
     }
 
     if (!this.isCacheActive) {


### PR DESCRIPTION
Ran into this issue while working in Angular Universal 6.0. We noticed that the transfer state wasn't accurately returning and that our page, despite having the initial transfer state rendered on the page, was still making an HTTP call to fetch the data because it was producing a cache miss here.

This was happening because we were submitting PUT/POST requests for reporting at a an earlier point in time. In my opinion, there is not a good reason to invalidate this cache for any reason other than the application becoming stable. This code reflects that and it was a simple enough change for our usage so we are trying to commit it back.