### PR TITLE
Is not working if DOMContentLoaded already fired.

### DIFF
--- a/modules/common/src/state-transfer-initializer/module.ts
+++ b/modules/common/src/state-transfer-initializer/module.ts
@@ -15,7 +15,13 @@ export function domContentLoadedFactory(doc: Document) {
       doc.removeEventListener('DOMContentLoaded', contentLoaded);
       resolve();
     };
-    doc.addEventListener('DOMContentLoaded', contentLoaded);
+    if (doc.readyState === "complete" || doc.readyState === "loaded") {
+      // document is already ready to go
+      resolve();
+    }
+    else{
+      doc.addEventListener('DOMContentLoaded', contentLoaded);
+    }
   });
 }
 


### PR DESCRIPTION
If `DOMContentLoaded` event already fired and after adding a listener for `DOMContentLoaded` event, then it will not execute.

So added a check to `resolve()` the promise if `DOMContentLoaded` event already fired.