### PR TITLE
test: re-enable unit tests

### DIFF
--- a/modules/express-engine/BUILD.bazel
+++ b/modules/express-engine/BUILD.bazel
@@ -33,6 +33,19 @@ ng_package(
     ],
 )
 
+# NgModule used only for tests.
+ng_module(
+    name = "testing",
+    srcs = glob([
+        "testing/**/*.ts",
+    ]),
+    deps = [
+        ":express-engine",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-server",
+    ],
+)
+
 ng_test_library(
     name = "unit_test_lib",
     srcs = glob([
@@ -40,6 +53,7 @@ ng_test_library(
     ]),
     deps = [
         ":express-engine",
+        ":testing",
         "//modules/express-engine/tokens",
         "@npm//@angular/compiler",
         "@npm//@angular/platform-browser",

--- a/modules/express-engine/testing/mock.server.module.ts
+++ b/modules/express-engine/testing/mock.server.module.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Component, Inject, InjectionToken, NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {ServerModule} from '@angular/platform-server';
+import {REQUEST} from '@nguniversal/express-engine/tokens';
+
+@Component({selector: 'root', template: 'some template'})
+export class MockComponent {
+}
+
+@NgModule({
+  imports: [BrowserModule.withServerTransition({appId: 'mock'}), ServerModule],
+  declarations: [MockComponent],
+  bootstrap: [MockComponent],
+})
+export class MockServerModule {
+}
+
+@Component({selector: 'root', template: `url:{{_req.url}}`})
+export class RequestComponent {
+  constructor(@Inject(REQUEST) public readonly _req: any) {}
+}
+
+@NgModule({
+  imports: [BrowserModule.withServerTransition({appId: 'mock'}), ServerModule],
+  declarations: [RequestComponent],
+  bootstrap: [RequestComponent],
+})
+export class RequestServerModule {
+}
+
+export const SOME_TOKEN = new InjectionToken<string>('SOME_TOKEN');
+
+@Component({selector: 'root', template: `message:{{_someToken.message}}`})
+export class TokenComponent {
+  constructor(@Inject(SOME_TOKEN) public readonly _someToken: any) {}
+}
+
+@NgModule({
+  imports: [BrowserModule.withServerTransition({appId: 'mock'}), ServerModule],
+  declarations: [TokenComponent],
+  bootstrap: [TokenComponent],
+})
+export class TokenServerModule {
+}

--- a/modules/hapi-engine/BUILD.bazel
+++ b/modules/hapi-engine/BUILD.bazel
@@ -31,6 +31,18 @@ ng_package(
     ],
 )
 
+# NgModule used only for tests.
+ng_module(
+    name = "testing",
+    srcs = glob([
+        "testing/**/*.ts",
+    ]),
+    deps = [
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-server",
+    ],
+)
+
 ng_test_library(
     name = "unit_test_lib",
     srcs = glob([
@@ -38,6 +50,7 @@ ng_test_library(
     ]),
     deps = [
         ":hapi-engine",
+        ":testing",
         "@npm//@angular/platform-browser",
         "@npm//@angular/platform-server",
         "@npm//@types/hapi",

--- a/modules/hapi-engine/spec/index.spec.ts
+++ b/modules/hapi-engine/spec/index.spec.ts
@@ -1,25 +1,10 @@
-import {Component, destroyPlatform, getPlatform, NgModule} from '@angular/core';
-import {ServerModule} from '@angular/platform-server';
+import {destroyPlatform, getPlatform} from '@angular/core';
 import {ngHapiEngine} from '@nguniversal/hapi-engine';
 import {ServerInjectResponse, Request, Server} from 'hapi';
+import {ExampleModuleNgFactory} from '../testing/example.ngfactory';
 import 'zone.js';
-import {BrowserModule} from '@angular/platform-browser';
 
-@Component({selector: 'app', template: `Works!`})
-class MyServerApp {
-}
-
-
-@NgModule({
-  bootstrap: [MyServerApp],
-  declarations: [MyServerApp],
-  imports: [ServerModule, BrowserModule.withServerTransition({appId: 'hapi-test'})],
-})
-class ExampleModule {
-}
-
-// tslint:disable
-xdescribe('test runner', () => {
+describe('test runner', () => {
 
   const server = new Server({ debug: false });
   server.route([
@@ -27,7 +12,7 @@ xdescribe('test runner', () => {
       method: 'GET',
       path: '/',
       handler: (req: Request) => ngHapiEngine({
-        bootstrap: ExampleModule,
+        bootstrap: ExampleModuleNgFactory,
         req,
         document: '<html><body><app></app></body></html>'
       })

--- a/modules/hapi-engine/testing/example.ts
+++ b/modules/hapi-engine/testing/example.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Component, NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {ServerModule} from '@angular/platform-server';
+
+@Component({selector: 'app', template: `Works!`})
+export class MyServerApp {
+}
+
+@NgModule({
+  bootstrap: [MyServerApp],
+  declarations: [MyServerApp],
+  imports:
+      [ServerModule, BrowserModule.withServerTransition({appId: 'hapi-test'})],
+})
+export class ExampleModule {
+}

--- a/modules/socket-engine/BUILD.bazel
+++ b/modules/socket-engine/BUILD.bazel
@@ -28,6 +28,18 @@ ng_package(
     ],
 )
 
+# NgModule used only for tests.
+ng_module(
+    name = "testing",
+    srcs = glob([
+        "testing/**/*.ts",
+    ]),
+    deps = [
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-server",
+    ],
+)
+
 ng_test_library(
     name = "unit_test_lib",
     srcs = glob([
@@ -35,6 +47,7 @@ ng_test_library(
     ]),
     deps = [
         ":socket-engine",
+        ":testing",
         "@npm//@angular/platform-browser",
         "@npm//@angular/platform-server",
         "@npm//domino",

--- a/modules/socket-engine/spec/index.spec.ts
+++ b/modules/socket-engine/spec/index.spec.ts
@@ -1,32 +1,19 @@
-import { ServerModule } from '@angular/platform-server';
-import { NgModule, Component, Inject, InjectionToken } from '@angular/core';
+import { SOME_TOKEN } from '../testing/mock.server.module';
+import {
+  MockServerModuleNgFactory,
+  ErrorServerModuleNgFactory,
+  TokenServerModuleNgFactory
+} from '../testing/mock.server.module.ngfactory';
 import 'zone.js';
 
-import { BrowserModule } from '@angular/platform-browser';
 import { startSocketEngine, SocketEngineResponse,
   SocketEngineRenderOptions } from '@nguniversal/socket-engine';
 import * as net from 'net';
 
-export function makeTestingModule(template: string, component?: any): any {
-  @Component({
-    selector: 'root',
-    template: template
-  })
-  class MockComponent {}
-  @NgModule({
-    imports: [ServerModule, BrowserModule.withServerTransition({appId: 'mock'})],
-    declarations: [component || MockComponent],
-    bootstrap: [component || MockComponent]
-  })
-  class MockServerModule {}
-  return MockServerModule;
-}
-
-async function sendAndRecieve(renderOptions: SocketEngineRenderOptions, template = '') {
+async function sendAndRecieve(renderOptions: SocketEngineRenderOptions) {
   return new Promise<SocketEngineResponse>(async(resolve, _reject) => {
 
-    const appModule = makeTestingModule(template);
-    const server = await startSocketEngine(appModule);
+    const server = await startSocketEngine(MockServerModuleNgFactory);
 
     const client = net.createConnection(9090, 'localhost', () => {
       client.write(JSON.stringify(renderOptions));
@@ -40,32 +27,24 @@ async function sendAndRecieve(renderOptions: SocketEngineRenderOptions, template
   });
 }
 
-// tslint:disable
-xdescribe('test runner', () => {
-  it('should render a basic template', async (done) => {
-    const template = `${new Date()}`;
+describe('test runner', () => {
+  it('should render a basic template', async () => {
     const renderOptions = {id: 1, url: '/path',
         document: '<root></root>'} as SocketEngineRenderOptions;
-    const result = await sendAndRecieve(renderOptions, template);
-    expect(result.html).toContain(template);
-    done();
+    const result = await sendAndRecieve(renderOptions);
+    expect(result.html).toContain('some template');
   });
-  it('should return the same id', async(done) => {
+
+  it('should return the same id', async () => {
     const id = Math.random();
     const renderOptions = {id , url: '/path',
         document: '<root></root>'} as SocketEngineRenderOptions;
     const result = await sendAndRecieve(renderOptions);
     expect(result.id).toEqual(id);
-    done();
   });
-  it('should return an error if it cant render', async(done) => {
-    @Component({
-      selector: 'root',
-      template: ''
-    })
-    class MockComponent {constructor(_illMakeItThrow: '') {}}
-    const appModule = makeTestingModule('', MockComponent);
-    const server = await startSocketEngine(appModule);
+
+  it('should return an error if it cant render', async (done) => {
+    const server = await startSocketEngine(ErrorServerModuleNgFactory);
 
     const client = net.createConnection(9090, 'localhost', () => {
       const renderOptions = {id: 1, url: '/path',
@@ -80,24 +59,19 @@ xdescribe('test runner', () => {
       done();
     });
   });
-  it('should return an error if it cant render', async(done) => {
-    const template = `${new Date()}`;
+
+  it('should not return an error if it can render', async () => {
     const renderOptions = {id: 1, url: '/path',
         document: '<root></root>'} as SocketEngineRenderOptions;
-    const result = await sendAndRecieve(renderOptions, template);
+    const result = await sendAndRecieve(renderOptions);
     expect(result.error).toBeUndefined();
-    done();
   });
-  it('should be able to inject some token', async(done) => {
-    const SOME_TOKEN = new InjectionToken<string>('SOME_TOKEN');
+
+  it('should be able to inject some token', async (done) => {
     const someValue = {message: 'value' + new Date()};
-    @Component({
-      selector: 'root',
-      template: `message:{{_someToken.message}}`
-    })
-    class MockComponent {constructor(@Inject(SOME_TOKEN) public readonly _someToken: any) {}}
-    const appModule = makeTestingModule('', MockComponent);
-    const server = await startSocketEngine(appModule, [{provide: SOME_TOKEN, useValue: someValue}]);
+    const server =
+      await startSocketEngine(
+        TokenServerModuleNgFactory, [{provide: SOME_TOKEN, useValue: someValue}]);
 
     const client = net.createConnection(9090, 'localhost', () => {
       const renderOptions = {id: 1, url: '/path',

--- a/modules/socket-engine/src/main.ts
+++ b/modules/socket-engine/src/main.ts
@@ -43,8 +43,7 @@ export function startSocketEngine(
         } catch (error) {
           // send the error down to the client then rethrow it
           socket.write(JSON.stringify({html: null,
-            id: renderOptions.id, error} as SocketEngineResponse));
-          throw error;
+            id: renderOptions.id, error: error.toString()} as SocketEngineResponse));
         }
       });
     });

--- a/modules/socket-engine/testing/mock.server.module.ts
+++ b/modules/socket-engine/testing/mock.server.module.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Component, NgModule, Inject, InjectionToken} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {ServerModule} from '@angular/platform-server';
+
+@Component({selector: 'root', template: 'some template'})
+export class MockComponent {
+}
+
+@NgModule({
+  imports: [BrowserModule.withServerTransition({appId: 'mock'}), ServerModule],
+  declarations: [MockComponent],
+  bootstrap: [MockComponent],
+})
+export class MockServerModule {
+}
+
+@Component({selector: 'root', template: 'some template'})
+export class ErrorComponent {
+  constructor() {
+    throw new Error('Error!');
+  }
+}
+
+@NgModule({
+  imports: [BrowserModule.withServerTransition({appId: 'mock'}), ServerModule],
+  declarations: [ErrorComponent],
+  bootstrap: [ErrorComponent],
+})
+export class ErrorServerModule {
+}
+
+export const SOME_TOKEN = new InjectionToken<string>('SOME_TOKEN');
+
+@Component({selector: 'root', template: `message:{{_someToken.message}}`})
+export class TokenComponent {
+  constructor(@Inject(SOME_TOKEN) public readonly _someToken: any) {}
+}
+
+@NgModule({
+  imports: [BrowserModule.withServerTransition({appId: 'mock'}), ServerModule],
+  declarations: [TokenComponent],
+  bootstrap: [TokenComponent],
+})
+export class TokenServerModule {
+}


### PR DESCRIPTION
Unit tests can run again with dependency on @angular/http removed.

Needed to convert the tests to use AOT-ed factory instead of relying on
JIT because that no longer works with Bazel and using Angular packages
from npm instead of compiling from source.