### PR TITLE
fix(schematics): ng add removes options from browser builder

### DIFF
--- a/modules/express-engine/schematics/install/index.spec.ts
+++ b/modules/express-engine/schematics/install/index.spec.ts
@@ -131,8 +131,23 @@ describe('Universal Schematic', () => {
       .toPromise();
     const filePath = '/projects/bar/src/main.server.ts';
     const contents = tree.readContent(filePath);
-    console.log({contents});
     expect(contents).toContain('ngExpressEngine');
     expect(contents).toContain('provideModuleMap');
+  });
+
+  it('should update angular.json', async () => {
+    const tree = await schematicRunner
+      .runSchematicAsync('ng-add', defaultOptions, appTree)
+      .toPromise();
+    const contents = JSON.parse(tree.readContent('angular.json'));
+    const architect = contents.projects.bar.architect;
+    expect(architect.build.configurations.production).toBeDefined();
+    expect(architect.build.options.outputPath).toBe('dist/browser');
+    expect(architect.server.options.outputPath).toBe('dist/server');
+
+    const productionConfig = architect.server.configurations.production;
+    expect(productionConfig.fileReplacements).toBeDefined();
+    expect(productionConfig.optimization).toBeDefined();
+    expect(productionConfig.sourceMap).toBeDefined();
   });
 });

--- a/modules/express-engine/schematics/install/index.ts
+++ b/modules/express-engine/schematics/install/index.ts
@@ -116,7 +116,7 @@ function updateConfigFile(options: UniversalOptions) {
     const clientProject = workspace.projects.get(options.clientProject);
     if (clientProject) {
       const buildTarget = clientProject.targets.get('build');
-      const serverTarget = clientProject.targets.get('build');
+      const serverTarget = clientProject.targets.get('server');
 
       // We have to check if the project config has a server target, because
       // if the Universal step in this schematic isn't run, it can't be guaranteed
@@ -125,23 +125,13 @@ function updateConfigFile(options: UniversalOptions) {
         return;
       }
 
-      serverTarget.configurations = {
-        production: {
-          fileReplacements: [
-            {
-              replace: 'src/environments/environment.ts',
-              with: 'src/environments/environment.prod.ts'
-            }
-          ]
-        }
-      };
-
       serverTarget.options = {
         ...serverTarget.options,
         outputPath: SERVER_DIST,
       };
 
       buildTarget.options = {
+        ...buildTarget.options,
         outputPath: BROWSER_DIST,
       };
     }

--- a/modules/hapi-engine/schematics/install/index.spec.ts
+++ b/modules/hapi-engine/schematics/install/index.spec.ts
@@ -131,8 +131,23 @@ describe('Universal Schematic', () => {
       .toPromise();
     const filePath = '/projects/bar/src/main.server.ts';
     const contents = tree.readContent(filePath);
-    console.log({contents});
     expect(contents).toContain('ngHapiEngine');
     expect(contents).toContain('provideModuleMap');
+  });
+
+  it('should update angular.json', async () => {
+    const tree = await schematicRunner
+      .runSchematicAsync('ng-add', defaultOptions, appTree)
+      .toPromise();
+    const contents = JSON.parse(tree.readContent('angular.json'));
+    const architect = contents.projects.bar.architect;
+    expect(architect.build.configurations.production).toBeDefined();
+    expect(architect.build.options.outputPath).toBe('dist/browser');
+    expect(architect.server.options.outputPath).toBe('dist/server');
+
+    const productionConfig = architect.server.configurations.production;
+    expect(productionConfig.fileReplacements).toBeDefined();
+    expect(productionConfig.sourceMap).toBeDefined();
+    expect(productionConfig.optimization).toBeDefined();
   });
 });

--- a/modules/hapi-engine/schematics/install/index.ts
+++ b/modules/hapi-engine/schematics/install/index.ts
@@ -121,7 +121,7 @@ function updateConfigFile(options: UniversalOptions) {
     const clientProject = workspace.projects.get(options.clientProject);
     if (clientProject) {
       const buildTarget = clientProject.targets.get('build');
-      const serverTarget = clientProject.targets.get('build');
+      const serverTarget = clientProject.targets.get('server');
 
       // We have to check if the project config has a server target, because
       // if the Universal step in this schematic isn't run, it can't be guaranteed
@@ -130,23 +130,13 @@ function updateConfigFile(options: UniversalOptions) {
         return;
       }
 
-      serverTarget.configurations = {
-        production: {
-          fileReplacements: [
-            {
-              replace: 'src/environments/environment.ts',
-              with: 'src/environments/environment.prod.ts'
-            }
-          ]
-        }
-      };
-
       serverTarget.options = {
         ...serverTarget.options,
         outputPath: SERVER_DIST,
       };
 
       buildTarget.options = {
+        ...buildTarget.options,
         outputPath: BROWSER_DIST,
       };
     }


### PR DESCRIPTION
This fixes a couple of regressions in the latest version. Were running `ng add` would cause configuration from the browser builder to be deleted instead of updated

Fixes #1189