### PR TITLE
build: under bazel runfiles symlinks are not created in windows

### DIFF
--- a/modules/express-engine/schematics/testing/test-app.ts
+++ b/modules/express-engine/schematics/testing/test-app.ts
@@ -7,12 +7,12 @@
  */
 
 import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
-import {join} from 'path';
 import {Observable} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 /** Path to the collection file for the NgUniversal schematics */
-export const collectionPath = join(__dirname, '..', 'collection.json');
+export const collectionPath =
+  require.resolve('nguniversal/modules/express-engine/schematics/collection.json');
 
 /** Create a base app used for testing. */
 export function createTestApp(appOptions = {}): Observable<UnitTestTree> {

--- a/modules/hapi-engine/schematics/testing/test-app.ts
+++ b/modules/hapi-engine/schematics/testing/test-app.ts
@@ -7,12 +7,12 @@
  */
 
 import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
-import {join} from 'path';
 import {Observable} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 /** Path to the collection file for the NgUniversal schematics */
-export const collectionPath = join(__dirname, '..', 'collection.json');
+export const collectionPath =
+  require.resolve('nguniversal/modules/hapi-engine/schematics/collection.json');
 
 /** Create a base app used for testing. */
 export function createTestApp(appOptions = {}): Observable<UnitTestTree> {


### PR DESCRIPTION
Under bazel require.resolve is patched and we should use it to resolve runfile artifacts so that tests can run on platforms were bazel will not create symlinks such as Windows