### PR TITLE
build: enable verbose_failures for CI

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -5,3 +5,9 @@
 # Save downloaded repositories in a location that can be cached by CircleCI. This helps us
 # speeding up the analysis time significantly with Bazel managed node dependencies on the CI.
 build --experimental_repository_cache=/home/circleci/bazel_repository_cache
+
+# Retry in the event of flakes, eg. https://circleci.com/gh/angular/universal/1768
+test --flaky_test_attempts=2
+
+# More details on failures
+build --verbose_failures=true


### PR DESCRIPTION
When a tests fails in CI it will be useful that failures are disabled in CI as not all users have SSH access.

Also this adds `flaky_test_attempts` to 2 as this morning I noticed a flake on a tests which failed but passed when force pushing