### PR TITLE
fix(express-engine): export Express app from server.ts

### DIFF
--- a/integration/express-engine-ivy/server.ts
+++ b/integration/express-engine-ivy/server.ts
@@ -6,33 +6,34 @@ import { join } from 'path';
 
 import { AppServerModule } from './src/main.server';
 
+// The Express app is exported so that it can be used by serverless Functions.
+export const app = express();
+const distFolder = join(process.cwd(), 'dist/express-engine-ivy/browser');
+
+// Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
+app.engine('html', ngExpressEngine({
+  bootstrap: AppServerModule,
+}));
+
+app.set('view engine', 'html');
+app.set('views', distFolder);
+
+// Example Express Rest API endpoints
+// app.get('/api/**', (req, res) => { });
+// Serve static files from /browser
+app.get('*.*', express.static(distFolder, {
+  maxAge: '1y'
+}));
+
+// All regular routes use the Universal engine
+app.get('*', (req, res) => {
+  res.render('index', { req });
+});
+
 // Express server
 function run() {
-  const app = express();
-  const port: string | number = process.env.PORT || 4000;
-  const distFolder = join(process.cwd(), 'dist/express-engine-ivy/browser');
-
-  // Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
-  app.engine('html', ngExpressEngine({
-    bootstrap: AppServerModule,
-  }));
-
-  app.set('view engine', 'html');
-  app.set('views', distFolder);
-
-  // Example Express Rest API endpoints
-  // app.get('/api/**', (req, res) => { });
-  // Serve static files from /browser
-  app.get('*.*', express.static(distFolder, {
-    maxAge: '1y'
-  }));
-
-  // All regular routes use the Universal engine
-  app.get('*', (req, res) => {
-    res.render('index', { req });
-  });
-
   // Start up the Node server
+  const port: string | number = process.env.PORT || 4000;
   app.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });

--- a/integration/express-engine-ve/server.ts
+++ b/integration/express-engine-ve/server.ts
@@ -6,33 +6,34 @@ import { join } from 'path';
 
 import { AppServerModuleNgFactory } from './src/main.server';
 
+// The Express app is exported so that it can be used by serverless Functions.
+export const app = express();
+const distFolder = join(process.cwd(), 'dist/express-engine-ve/browser');
+
+// Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
+app.engine('html', ngExpressEngine({
+  bootstrap: AppServerModuleNgFactory,
+}));
+
+app.set('view engine', 'html');
+app.set('views', distFolder);
+
+// Example Express Rest API endpoints
+// app.get('/api/**', (req, res) => { });
+// Serve static files from /browser
+app.get('*.*', express.static(distFolder, {
+  maxAge: '1y'
+}));
+
+// All regular routes use the Universal engine
+app.get('*', (req, res) => {
+  res.render('index', { req });
+});
+
 // Express server
 function run() {
-  const app = express();
-  const port: string | number = process.env.PORT || 4000;
-  const distFolder = join(process.cwd(), 'dist/express-engine-ve/browser');
-
-  // Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
-  app.engine('html', ngExpressEngine({
-    bootstrap: AppServerModuleNgFactory,
-  }));
-
-  app.set('view engine', 'html');
-  app.set('views', distFolder);
-
-  // Example Express Rest API endpoints
-  // app.get('/api/**', (req, res) => { });
-  // Serve static files from /browser
-  app.get('*.*', express.static(distFolder, {
-    maxAge: '1y'
-  }));
-
-  // All regular routes use the Universal engine
-  app.get('*', (req, res) => {
-    res.render('index', { req });
-  });
-
   // Start up the Node server
+  const port: string | number = process.env.PORT || 4000;
   app.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });

--- a/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -6,33 +6,34 @@ import { join } from 'path';
 
 import { AppServerModule } from './src/<%= stripTsExtension(main) %>';
 
+// The Express app is exported so that it can be used by serverless Functions.
+export const app = express();
+const distFolder = join(process.cwd(), '<%= browserDistDirectory %>');
+
+// Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
+app.engine('html', ngExpressEngine({
+  bootstrap: AppServerModule,
+}));
+
+app.set('view engine', 'html');
+app.set('views', distFolder);
+
+// Example Express Rest API endpoints
+// app.get('/api/**', (req, res) => { });
+// Serve static files from /browser
+app.get('*.*', express.static(distFolder, {
+  maxAge: '1y'
+}));
+
+// All regular routes use the Universal engine
+app.get('*', (req, res) => {
+  res.render('index', { req });
+});
+
 // Express server
 function run() {
-  const app = express();
-  const port: string | number = process.env.PORT || <%= serverPort %>;
-  const distFolder = join(process.cwd(), '<%= browserDistDirectory %>');
-
-  // Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
-  app.engine('html', ngExpressEngine({
-    bootstrap: AppServerModule,
-  }));
-
-  app.set('view engine', 'html');
-  app.set('views', distFolder);
-
-  // Example Express Rest API endpoints
-  // app.get('/api/**', (req, res) => { });
-  // Serve static files from /browser
-  app.get('*.*', express.static(distFolder, {
-    maxAge: '1y'
-  }));
-
-  // All regular routes use the Universal engine
-  app.get('*', (req, res) => {
-    res.render('index', { req });
-  });
-
   // Start up the Node server
+  const port: string | number = process.env.PORT || <%= serverPort %>;
   app.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });


### PR DESCRIPTION
Change the schematics to export the Express app object itself from
server.ts.

This can be used from a serverless function to call into the Express app
directly. Example -
https://github.com/angular/angularfire2/blob/master/docs/universal/cloud-functions.md