### PR TITLE
fix(hapi-engine, express-engine): export app for serverless functions

### DIFF
--- a/integration/express-engine-ivy/server.ts
+++ b/integration/express-engine-ivy/server.ts
@@ -7,34 +7,40 @@ import { join } from 'path';
 import { AppServerModule } from './src/main.server';
 
 // The Express app is exported so that it can be used by serverless Functions.
-export const app = express();
-const distFolder = join(process.cwd(), 'dist/express-engine-ivy/browser');
+export function app() {
+  const server = express();
+  const distFolder = join(process.cwd(), 'dist/express-engine-ivy/browser');
 
-// Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
-app.engine('html', ngExpressEngine({
-  bootstrap: AppServerModule,
-}));
+  // Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
+  server.engine('html', ngExpressEngine({
+    bootstrap: AppServerModule,
+  }));
 
-app.set('view engine', 'html');
-app.set('views', distFolder);
+  server.set('view engine', 'html');
+  server.set('views', distFolder);
 
-// Example Express Rest API endpoints
-// app.get('/api/**', (req, res) => { });
-// Serve static files from /browser
-app.get('*.*', express.static(distFolder, {
-  maxAge: '1y'
-}));
+  // Example Express Rest API endpoints
+  // app.get('/api/**', (req, res) => { });
+  // Serve static files from /browser
+  server.get('*.*', express.static(distFolder, {
+    maxAge: '1y'
+  }));
 
-// All regular routes use the Universal engine
-app.get('*', (req, res) => {
-  res.render('index', { req });
-});
+  // All regular routes use the Universal engine
+  server.get('*', (req, res) => {
+    res.render('index', { req });
+  });
+
+  return server;
+}
 
 // Express server
 function run() {
-  // Start up the Node server
   const port: string | number = process.env.PORT || 4000;
-  app.listen(port, () => {
+
+  // Start up the Node server
+  const server = app();
+  server.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });
 }

--- a/integration/express-engine-ve/server.ts
+++ b/integration/express-engine-ve/server.ts
@@ -7,34 +7,40 @@ import { join } from 'path';
 import { AppServerModuleNgFactory } from './src/main.server';
 
 // The Express app is exported so that it can be used by serverless Functions.
-export const app = express();
-const distFolder = join(process.cwd(), 'dist/express-engine-ve/browser');
+export function app() {
+  const server = express();
+  const distFolder = join(process.cwd(), 'dist/express-engine-ve/browser');
 
-// Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
-app.engine('html', ngExpressEngine({
-  bootstrap: AppServerModuleNgFactory,
-}));
+  // Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
+  server.engine('html', ngExpressEngine({
+    bootstrap: AppServerModuleNgFactory,
+  }));
 
-app.set('view engine', 'html');
-app.set('views', distFolder);
+  server.set('view engine', 'html');
+  server.set('views', distFolder);
 
-// Example Express Rest API endpoints
-// app.get('/api/**', (req, res) => { });
-// Serve static files from /browser
-app.get('*.*', express.static(distFolder, {
-  maxAge: '1y'
-}));
+  // Example Express Rest API endpoints
+  // app.get('/api/**', (req, res) => { });
+  // Serve static files from /browser
+  server.get('*.*', express.static(distFolder, {
+    maxAge: '1y'
+  }));
 
-// All regular routes use the Universal engine
-app.get('*', (req, res) => {
-  res.render('index', { req });
-});
+  // All regular routes use the Universal engine
+  server.get('*', (req, res) => {
+    res.render('index', { req });
+  });
+
+  return server;
+}
 
 // Express server
 function run() {
-  // Start up the Node server
   const port: string | number = process.env.PORT || 4000;
-  app.listen(port, () => {
+
+  // Start up the Node server
+  const server = app();
+  server.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });
 }

--- a/integration/hapi-engine-ve/server.ts
+++ b/integration/hapi-engine-ve/server.ts
@@ -5,15 +5,15 @@ import * as inert from 'inert';
 import { Request, Server, ResponseToolkit } from 'hapi';
 import { join } from 'path';
 import { readFileSync } from 'fs';
+
 import { AppServerModuleNgFactory } from './src/main.server';
 
-// Hapi server
-async function run(): Promise<void> {
+// The Hapi server is exported so that it can be used by serverless functions.
+export async function app() {
   const port: string | number = process.env.PORT || 4000;
   const distFolder = join(process.cwd(), 'dist/hapi-engine-ve/browser');
   const server = new Server({
     port,
-    host: 'localhost',
     routes: {
       files: {
         relativeTo: distFolder
@@ -43,8 +43,13 @@ async function run(): Promise<void> {
       res.file(`${req.params.filename}.${req.params.ext}`)
   });
 
+  return server;
+}
+
+async function run(): Promise<void> {
+  const server = await app();
   await server.start();
-  console.log(`Node Hapi server listening on http://localhost:${port}`);
+  console.log(`Node Hapi server listening on http://${server.info.host}:${server.info.port}`);
 }
 
 // Webpack will replace 'require' with '__webpack_require__'
@@ -53,7 +58,10 @@ async function run(): Promise<void> {
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
 if (mainModule && mainModule.filename === __filename) {
-  run();
+  run().catch(error => {
+    console.error(`Error: ${error.toString()}`);
+    process.exit(1);
+  });
 }
 
 export * from './src/main.server';

--- a/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -7,34 +7,40 @@ import { join } from 'path';
 import { AppServerModule } from './src/<%= stripTsExtension(main) %>';
 
 // The Express app is exported so that it can be used by serverless Functions.
-export const app = express();
-const distFolder = join(process.cwd(), '<%= browserDistDirectory %>');
+export function app() {
+  const server = express();
+  const distFolder = join(process.cwd(), '<%= browserDistDirectory %>');
 
-// Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
-app.engine('html', ngExpressEngine({
-  bootstrap: AppServerModule,
-}));
+  // Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
+  server.engine('html', ngExpressEngine({
+    bootstrap: AppServerModule,
+  }));
 
-app.set('view engine', 'html');
-app.set('views', distFolder);
+  server.set('view engine', 'html');
+  server.set('views', distFolder);
 
-// Example Express Rest API endpoints
-// app.get('/api/**', (req, res) => { });
-// Serve static files from /browser
-app.get('*.*', express.static(distFolder, {
-  maxAge: '1y'
-}));
+  // Example Express Rest API endpoints
+  // app.get('/api/**', (req, res) => { });
+  // Serve static files from /browser
+  server.get('*.*', express.static(distFolder, {
+    maxAge: '1y'
+  }));
 
-// All regular routes use the Universal engine
-app.get('*', (req, res) => {
-  res.render('index', { req });
-});
+  // All regular routes use the Universal engine
+  server.get('*', (req, res) => {
+    res.render('index', { req });
+  });
+
+  return server;
+}
 
 // Express server
 function run() {
-  // Start up the Node server
   const port: string | number = process.env.PORT || <%= serverPort %>;
-  app.listen(port, () => {
+
+  // Start up the Node server
+  const server = app();
+  server.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });
 }

--- a/modules/hapi-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/hapi-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -8,13 +8,12 @@ import { readFileSync } from 'fs';
 
 import { AppServerModule } from './src/<%= stripTsExtension(main) %>';
 
-// Hapi server
-async function run(): Promise<void> {
+// The Hapi server is exported so that it can be used by serverless functions.
+export async function app() {
   const port: string | number = process.env.PORT || <%= serverPort %>;
   const distFolder = join(process.cwd(), '<%= browserDistDirectory %>');
   const server = new Server({
     port,
-    host: 'localhost',
     routes: {
       files: {
         relativeTo: distFolder
@@ -44,8 +43,13 @@ async function run(): Promise<void> {
       res.file(`${req.params.filename}.${req.params.ext}`)
   });
 
+  return server;
+}
+
+async function run(): Promise<void> {
+  const server = await app();
   await server.start();
-  console.log(`Node Hapi server listening on http://localhost:${port}`);
+  console.log(`Node Hapi server listening on http://${server.info.host}:${server.info.port}`);
 }
 
 // Webpack will replace 'require' with '__webpack_require__'


### PR DESCRIPTION
Export Hapi and Express app from the server bundle so that they can be
referenced in serverless functions if needed.