### PR TITLE
fix(express-engine): set APP_BASE_HREF to req.baseUrl

### DIFF
--- a/integration/express-engine-ivy/server.ts
+++ b/integration/express-engine-ivy/server.ts
@@ -5,6 +5,7 @@ import * as express from 'express';
 import { join } from 'path';
 
 import { AppServerModule } from './src/main.server';
+import { APP_BASE_HREF } from '@angular/common';
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app() {
@@ -28,7 +29,7 @@ export function app() {
 
   // All regular routes use the Universal engine
   server.get('*', (req, res) => {
-    res.render('index', { req });
+    res.render('index', { req, providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }] });
   });
 
   return server;

--- a/integration/express-engine-ve/server.ts
+++ b/integration/express-engine-ve/server.ts
@@ -5,6 +5,7 @@ import * as express from 'express';
 import { join } from 'path';
 
 import { AppServerModuleNgFactory } from './src/main.server';
+import { APP_BASE_HREF } from '@angular/common';
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app() {
@@ -28,7 +29,7 @@ export function app() {
 
   // All regular routes use the Universal engine
   server.get('*', (req, res) => {
-    res.render('index', { req });
+    res.render('index', { req, providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }] });
   });
 
   return server;

--- a/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -5,6 +5,7 @@ import * as express from 'express';
 import { join } from 'path';
 
 import { AppServerModule } from './src/<%= stripTsExtension(main) %>';
+import { APP_BASE_HREF } from '@angular/common';
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app() {
@@ -28,7 +29,7 @@ export function app() {
 
   // All regular routes use the Universal engine
   server.get('*', (req, res) => {
-    res.render('index', { req });
+    res.render('index', { req, providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }] });
   });
 
   return server;


### PR DESCRIPTION
This avoids Angular route match failures when the Express engine is
mounted on a different URL (Happens with Firebase and other serverless
setup).