### PR TITLE
support `ng-add` without specifying `clientProject`

### DIFF
--- a/modules/express-engine/schematics/install/schema.json
+++ b/modules/express-engine/schematics/install/schema.json
@@ -6,7 +6,10 @@
   "properties": {
     "clientProject": {
       "type": "string",
-      "description": "Name of related client app."
+      "description": "Name of related client app.",
+      "$default": {
+        "$source": "projectName"
+      }
     },
     "appId": {
       "type": "string",

--- a/modules/hapi-engine/schematics/install/schema.json
+++ b/modules/hapi-engine/schematics/install/schema.json
@@ -6,7 +6,10 @@
   "properties": {
     "clientProject": {
       "type": "string",
-      "description": "Name of related client app."
+      "description": "Name of related client app.",
+      "$default": {
+        "$source": "projectName"
+      }
     },
     "appId": {
       "type": "string",


### PR DESCRIPTION
feat(express-engine): support `ng-add` without specifying `clientProject`

When unset we set the clientProject to the resolved packageName from the current working directory

Users can now use the schematic via:

```
ng add @nguniversal/express-engine
```


feat(hapi-engine): support `ng-add` without specifying `clientProject`

When unset we set the clientProject to the resolved packageName from the current working directory

Users can now use the schematic via:

```
ng add @nguniversal/hapi-engine
```
