### PR TITLE
ci: add `--silent` to yarn install

### DIFF
--- a/integration/run_tests.sh
+++ b/integration/run_tests.sh
@@ -36,7 +36,7 @@ for testDir in $(ls | grep -v node_modules) ; do
     cd $testDir
     rm -rf dist
 
-    yarn install --cache-folder ../$cache
+    yarn install --cache-folder ../$cache --silent
     yarn test || exit 1
 
     # remove the temporary node modules directory to keep the source folder clean.


### PR DESCRIPTION
At the moment, the integration tests CI tasks is full of install logs which are noisy and hide "more" import logs