### PR TITLE
fix(common): update server main option when using `ng add/ng update`

### DIFF
--- a/modules/common/schematics/add/index.spec.ts
+++ b/modules/common/schematics/add/index.spec.ts
@@ -34,6 +34,7 @@ describe('Add Schematic Rule', () => {
     expect(architect.build.configurations.production).toBeDefined();
     expect(architect.build.options.outputPath).toBe('dist/test-app/browser');
     expect(architect.server.options.outputPath).toBe('dist/test-app/server');
+    expect(architect.server.options.main).toBe('projects/test-app/server.ts');
 
     const productionConfig = architect.server.configurations.production;
     expect(productionConfig.fileReplacements).toBeDefined();


### PR DESCRIPTION
The server target main option needs to be updated when running the add schematic to point to the server.ts entrypoint