### PR TITLE
fix(express-engine, hapi-engine): remove `@nguniversal/module-map-ngf…

### DIFF
--- a/modules/common/schematics/BUILD.bazel
+++ b/modules/common/schematics/BUILD.bazel
@@ -26,6 +26,7 @@ ts_library(
         "@npm//@angular-devkit/schematics",
         "@npm//@schematics/angular",
         "@npm//rxjs",
+        "@npm//typescript",
     ],
 )
 

--- a/modules/common/schematics/migrations/update-9/index.spec.ts
+++ b/modules/common/schematics/migrations/update-9/index.spec.ts
@@ -34,6 +34,40 @@ describe('Migration to version 9', () => {
     tree.create('/projects/test-app/server.ts', 'server content');
     tree.create('/projects/test-app/webpack.server.config.js', 'webpack config content');
 
+    tree.overwrite('/projects/test-app/src/main.server.ts', `
+    import { enableProdMode } from '@angular/core';
+
+    import { environment } from './environments/environment';
+
+    if (environment.production) {
+      enableProdMode();
+    }
+
+    export { AppServerModule } from './app/app.server.module';
+    export { renderModule, renderModuleFactory } from '@angular/platform-server';
+    export { ngExpressEngine } from '@nguniversal/express-engine';
+    export { provideModuleMap } from '@nguniversal/module-map-ngfactory-loader';
+    `);
+
+    tree.overwrite('/projects/test-app/src/app/app.server.module.ts', `
+    import { NgModule } from '@angular/core';
+    import { ServerModule } from '@angular/platform-server';
+
+    import { AppModule } from './app.module';
+    import { AppComponent } from './app.component';
+    import { ModuleMapLoaderModule } from '@nguniversal/module-map-ngfactory-loader';
+
+    @NgModule({
+      imports: [
+        AppModule,
+        ServerModule,
+        ModuleMapLoaderModule,
+      ],
+      bootstrap: [AppComponent],
+    })
+    export class AppServerModule {}
+    `);
+
     const pkg = JSON.parse(tree.readContent('/package.json'));
     const scripts = pkg.scripts;
     scripts['compile:server'] = 'old compile:server';
@@ -68,5 +102,17 @@ describe('Migration to version 9', () => {
     const { scripts } = JSON.parse(newTree.read('/package.json')!.toString());
     expect(scripts['build:ssr']).toBeUndefined();
     expect(scripts['build:ssr_bak']).toBeUndefined();
+  });
+
+  it(`should remove '@nguniversal/module-map-ngfactory-loader' references`, async () => {
+    const newTree = await schematicRunner.callRule(version9UpdateRule(''), tree).toPromise();
+
+    const appServerModule =
+      newTree.read('/projects/test-app/src/app/app.server.module.ts')!.toString();
+    expect(appServerModule).not.toContain(`from '@nguniversal/module-map-ngfactory-loader';`);
+    expect(appServerModule).not.toContain('ModuleMapLoaderModule');
+
+    const mainServer = newTree.read('/projects/test-app/src/main.server.ts')!.toString();
+    expect(mainServer).not.toContain(`from '@nguniversal/module-map-ngfactory-loader';`);
   });
 });


### PR DESCRIPTION
…actory-loader` during `ng update`

String based lazy loading syntax is not support with Ivy and hence `@nguniversal/module-map-ngfactory-loader` is no longer required.

When not removed the application is left in a broken state with the following runtime error

```
NullInjectorError: R3InjectorError[router_RouterModule -> router_Router -> NgModuleFactoryLoader -> InjectionToken MODULE_MAP -> InjectionToken MODULE_MAP -> InjectionToken MODULE_MAP]:
```

Fixes: #1272