### PR TITLE
fix(hapi-engine, express-engine): `distFolder` const should contain t…

### DIFF
--- a/modules/express-engine/schematics/install/index.spec.ts
+++ b/modules/express-engine/schematics/install/index.spec.ts
@@ -72,4 +72,14 @@ describe('Universal Schematic', () => {
     const content = tree.readContent('/projects/test-app/server.ts');
     expect(content).toContain(`export * from './src/main.server'`);
   });
+
+  it(`should add correct value to 'distFolder'`, async () => {
+    const tree = await schematicRunner
+      .runSchematicAsync('ng-add', defaultOptions, appTree)
+      .toPromise();
+
+    const content = tree.readContent('/projects/test-app/server.ts');
+    expect(content)
+      .toContain(`const distFolder = join(process.cwd(), 'dist/test-app/browser');`);
+  });
 });

--- a/modules/express-engine/schematics/install/index.ts
+++ b/modules/express-engine/schematics/install/index.ts
@@ -54,24 +54,30 @@ function addDependencies(options: UniversalOptions): Rule {
   };
 }
 
-export default function (options: UniversalOptions): Rule {
-  return async (host: Tree) => {
+function addServerFile(options: UniversalOptions): Rule {
+  return async host => {
     const clientProject = await getProject(host, options.clientProject);
     const browserDistDirectory = await getOutputPath(host, options.clientProject, 'build');
 
-    const rootSource = apply(url('./files'), [
-      template({
-        ...strings,
-        ...options,
-        stripTsExtension,
-        browserDistDirectory,
-      }),
-      move(clientProject.root)
-    ]);
+    return mergeWith(
+        apply(url('./files'), [
+        template({
+          ...strings,
+          ...options,
+          stripTsExtension,
+          browserDistDirectory,
+        }),
+        move(clientProject.root)
+      ])
+    );
+  };
+}
 
+export default function (options: UniversalOptions): Rule {
+  return () => {
     return chain([
-      mergeWith(rootSource),
       addUniversalCommonRule(options),
+      addServerFile(options),
       addDependencies(options),
     ]);
   };

--- a/modules/hapi-engine/schematics/install/index.spec.ts
+++ b/modules/hapi-engine/schematics/install/index.spec.ts
@@ -72,4 +72,14 @@ describe('Universal Schematic', () => {
     const content = tree.readContent('/projects/test-app/server.ts');
     expect(content).toContain(`export * from './src/main.server'`);
   });
+
+  it(`should add correct value to 'distFolder'`, async () => {
+    const tree = await schematicRunner
+      .runSchematicAsync('ng-add', defaultOptions, appTree)
+      .toPromise();
+
+    const content = tree.readContent('/projects/test-app/server.ts');
+    expect(content)
+      .toContain(`const distFolder = join(process.cwd(), 'dist/test-app/browser');`);
+  });
 });

--- a/modules/hapi-engine/schematics/install/index.ts
+++ b/modules/hapi-engine/schematics/install/index.ts
@@ -59,24 +59,30 @@ function addDependencies(options: UniversalOptions): Rule {
   };
 }
 
-export default function (options: UniversalOptions): Rule {
-  return async (host: Tree) => {
+function addServerFile(options: UniversalOptions): Rule {
+  return async host => {
     const clientProject = await getProject(host, options.clientProject);
     const browserDistDirectory = await getOutputPath(host, options.clientProject, 'build');
 
-    const rootSource = apply(url('./files'), [
-      template({
-        ...strings,
-        ...options,
-        stripTsExtension,
-        browserDistDirectory,
-      }),
-      move(clientProject.root)
-    ]);
+    return mergeWith(
+        apply(url('./files'), [
+        template({
+          ...strings,
+          ...options,
+          stripTsExtension,
+          browserDistDirectory,
+        }),
+        move(clientProject.root)
+      ])
+    );
+  };
+}
 
+export default function (options: UniversalOptions): Rule {
+  return () => {
     return chain([
-      mergeWith(rootSource),
       addUniversalCommonRule(options),
+      addServerFile(options),
       addDependencies(options),
     ]);
   };


### PR DESCRIPTION
…he path to the contents of browser build.

This was reported on twitter,

Thanks Shane Osbourne!