### PR TITLE
feat(builders): implement ssr-dev-server

### DIFF
--- a/integration/express-engine-ivy/angular.json
+++ b/integration/express-engine-ivy/angular.json
@@ -95,6 +95,19 @@
             }
           }
         },
+        "ssr-serve": {
+          "builder": "@nguniversal/builders:ssr-dev-server",
+          "options": {
+            "browserTarget": "express-engine-ivy:build",
+            "serverTarget": "express-engine-ivy:server"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "express-engine-ivy:build:production",
+              "serverTarget": "express-engine-ivy:server:production"
+            }
+          }
+        },        
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {

--- a/integration/express-engine-ivy/package.json
+++ b/integration/express-engine-ivy/package.json
@@ -14,6 +14,7 @@
     "test": "npm run build && npm run serve:test",
     "serve:test": "concurrently \"npm run serve:ssr\" \"npm run e2e\" --kill-others --success first",
     "serve:ssr": "node dist/express-engine-ivy/server/main.js",
+    "serve:ssr-dev-server": "ng run express-engine-ivy:ssr-serve",
     "build:ssr": "npm run build:client-and-server-bundles",
     "build": "ng build --prod && ng run express-engine-ivy:server:production"
   },
@@ -40,6 +41,7 @@
     "@types/express": "file:../../node_modules/@types/express",
     "@types/node": "file:../../node_modules/@types/node",
     "@types/jasmine": "file:../../node_modules/@types/jasmine",
+    "@nguniversal/builders": "file:../../dist/modules-dist/builders",
     "codelyzer": "5.2.0",
     "concurrently": "5.0.0",
     "jasmine-core": "3.5.0",

--- a/integration/express-engine-ve/angular.json
+++ b/integration/express-engine-ve/angular.json
@@ -95,6 +95,19 @@
             }
           }
         },
+        "ssr-serve": {
+          "builder": "@nguniversal/builders:ssr-dev-server",
+          "options": {
+            "browserTarget": "express-engine-ve:build",
+            "serverTarget": "express-engine-ve:server"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "express-engine-ve:build:production",
+              "serverTarget": "express-engine-ve:server:production"
+            }
+          }
+        },         
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {

--- a/integration/express-engine-ve/package.json
+++ b/integration/express-engine-ve/package.json
@@ -14,6 +14,7 @@
     "test": "npm run build && npm run serve:test",
     "serve:test": "concurrently \"npm run serve:ssr\" \"npm run e2e\" --kill-others --success first",
     "serve:ssr": "node dist/express-engine-ve/server/main.js",
+    "serve:ssr-dev-server": "ng run express-engine-ve:ssr-serve",
     "build:ssr": "npm run build:client-and-server-bundles",
     "build": "ng build --prod && ng run express-engine-ve:server:production"
   },
@@ -40,6 +41,7 @@
     "@types/express": "file:../../node_modules/@types/express",
     "@types/node": "file:../../node_modules/@types/node",
     "@types/jasmine": "file:../../node_modules/@types/jasmine",
+    "@nguniversal/builders": "file:../../dist/modules-dist/builders",
     "codelyzer": "5.2.0",
     "concurrently": "5.0.0",
     "jasmine-core": "3.5.0",

--- a/integration/hapi-engine-ivy/angular.json
+++ b/integration/hapi-engine-ivy/angular.json
@@ -146,6 +146,19 @@
             "main": "server.ts",
             "tsConfig": "tsconfig.server.json"
           },
+          "ssr-serve": {
+            "builder": "@nguniversal/builders:ssr-dev-server",
+            "options": {
+              "browserTarget": "hapi-engine-ivy:build",
+              "serverTarget": "hapi-engine-ivy:server"
+            },
+            "configurations": {
+              "production": {
+                "browserTarget": "hapi-engine-ivy:build:production",
+                "serverTarget": "hapi-engine-ivy:server:production"
+              }
+            }
+          },           
           "configurations": {
             "production": {
               "fileReplacements": [

--- a/integration/hapi-engine-ivy/package.json
+++ b/integration/hapi-engine-ivy/package.json
@@ -14,6 +14,7 @@
     "test": "npm run build && npm run serve:test",
     "serve:test": "concurrently \"npm run serve:ssr\" \"npm run e2e\" --kill-others --success first",
     "serve:ssr": "node dist/hapi-engine-ivy/server/main.js",
+    "serve:ssr-dev-server": "ng run hapi-engine-ivy:ssr-serve",
     "build:ssr": "npm run build:client-and-server-bundles",
     "build": "ng build --prod && ng run hapi-engine-ivy:server:production"
   },
@@ -42,6 +43,7 @@
     "@types/hapi__inert": "^5.2.0",
     "@types/node": "file:../../node_modules/@types/node",
     "@types/jasmine": "file:../../node_modules/@types/jasmine",
+    "@nguniversal/builders": "file:../../dist/modules-dist/builders",
     "codelyzer": "5.2.0",
     "concurrently": "5.0.0",
     "jasmine-core": "3.5.0",

--- a/integration/hapi-engine-ve/angular.json
+++ b/integration/hapi-engine-ve/angular.json
@@ -146,6 +146,19 @@
             "main": "server.ts",
             "tsConfig": "tsconfig.server.json"
           },
+          "ssr-serve": {
+            "builder": "@nguniversal/builders:ssr-dev-server",
+            "options": {
+              "browserTarget": "hapi-engine-ve:build",
+              "serverTarget": "hapi-engine-ve:server"
+            },
+            "configurations": {
+              "production": {
+                "browserTarget": "hapi-engine-ve:build:production",
+                "serverTarget": "hapi-engine-ve:server:production"
+              }
+            }
+          },           
           "configurations": {
             "production": {
               "fileReplacements": [

--- a/integration/hapi-engine-ve/package.json
+++ b/integration/hapi-engine-ve/package.json
@@ -14,6 +14,7 @@
     "test": "npm run build && npm run serve:test",
     "serve:test": "concurrently \"npm run serve:ssr\" \"npm run e2e\" --kill-others --success first",
     "serve:ssr": "node dist/hapi-engine-ve/server/main.js",
+    "serve:ssr-dev-server": "ng run hapi-engine-ve:ssr-serve",
     "build:ssr": "npm run build:client-and-server-bundles",
     "build": "ng build --prod && ng run hapi-engine-ve:server:production"
   },
@@ -42,6 +43,7 @@
     "@types/hapi__inert": "^5.2.0",
     "@types/node": "file:../../node_modules/@types/node",
     "@types/jasmine": "file:../../node_modules/@types/jasmine",
+    "@nguniversal/builders": "file:../../dist/modules-dist/builders",
     "codelyzer": "5.2.0",
     "concurrently": "5.0.0",
     "jasmine-core": "3.5.0",

--- a/modules/builders/BUILD.bazel
+++ b/modules/builders/BUILD.bazel
@@ -38,5 +38,6 @@ ts_library(
 npm_package(
     name = "npm_package",
     srcs = [":builders_assets"],
+    tags = ["release"],
     deps = [":builders"],
 )


### PR DESCRIPTION
The ssr-dev-server builder starts the browser builder and the server builder in watch mode.
To show how it works, one can run the serve:ssr-dev-server npm script in the express-engine-ivy integration test project