### PR TITLE
fix(common): always pass `skipInstall` to `universal` schematic

### DIFF
--- a/modules/common/schematics/add/index.ts
+++ b/modules/common/schematics/add/index.ts
@@ -32,7 +32,10 @@ export function addUniversalCommonRule(options: AddUniversalOptions): Rule {
     return chain([
       clientProject.targets.has('server')
         ? noop()
-        : externalSchematic('@schematics/angular', 'universal', options),
+        : externalSchematic('@schematics/angular', 'universal', {
+          ...options,
+          skipInstall: true
+        }),
       addScriptsRule(options),
       updateServerTsConfigRule(options),
       updateWorkspaceConfigRule(options),

--- a/modules/express-engine/schematics/install/index.spec.ts
+++ b/modules/express-engine/schematics/install/index.spec.ts
@@ -46,7 +46,7 @@ describe('Universal Schematic', () => {
   it('should install npm dependencies', async () => {
     await schematicRunner.runSchematicAsync('ng-add', defaultOptions, appTree)
         .toPromise();
-    expect(schematicRunner.tasks.length).toBe(2);
+    expect(schematicRunner.tasks.length).toBe(1);
     expect(schematicRunner.tasks[0].name).toBe('node-package');
     expect((schematicRunner.tasks[0].options as {command: string}).command)
         .toBe('install');

--- a/modules/hapi-engine/schematics/install/index.spec.ts
+++ b/modules/hapi-engine/schematics/install/index.spec.ts
@@ -46,7 +46,7 @@ describe('Universal Schematic', () => {
   it('should install npm dependencies', async () => {
     await schematicRunner.runSchematicAsync('ng-add', defaultOptions, appTree)
         .toPromise();
-    expect(schematicRunner.tasks.length).toBe(2);
+    expect(schematicRunner.tasks.length).toBe(1);
     expect(schematicRunner.tasks[0].name).toBe('node-package');
     expect((schematicRunner.tasks[0].options as {command: string}).command)
         .toBe('install');


### PR DESCRIPTION
At the moment, we run `npm install` twice if the current project doesn't have a server target because we run 1 in our respective engine schematics, ex: https://github.com/angular/universal/blob/e4f078133c14fcb602baaabf8c277ff003d137f5/modules/hapi-engine/schematics/install/index.ts#L35-L37 and other in the external universal schematics.

With this change we disable the install in the external universal schematic and rely on install task in our code.