### PR TITLE
build: exclude schematics `testing` folder from being shipped

### DIFF
--- a/modules/common/schematics/BUILD.bazel
+++ b/modules/common/schematics/BUILD.bazel
@@ -15,6 +15,7 @@ ts_library(
     srcs = glob(
         ["**/*.ts"],
         exclude = [
+            "testing/**/*",
             "**/*.spec.ts",
             "**/files/**/*",
         ],
@@ -47,7 +48,10 @@ jasmine_node_test(
 ng_test_library(
     name = "schematics_test_sources",
     srcs = glob(
-        ["**/*.spec.ts"],
+        [
+            "testing/*.ts",
+            "**/*.spec.ts"
+        ],
         exclude = ["**/files/**/*"],
     ),
     tsconfig = ":tsconfig.json",

--- a/modules/common/schematics/BUILD.bazel
+++ b/modules/common/schematics/BUILD.bazel
@@ -50,7 +50,7 @@ ng_test_library(
     srcs = glob(
         [
             "testing/*.ts",
-            "**/*.spec.ts"
+            "**/*.spec.ts",
         ],
         exclude = ["**/files/**/*"],
     ),

--- a/modules/common/schematics/testing/test-app.ts
+++ b/modules/common/schematics/testing/test-app.ts
@@ -6,27 +6,28 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
-import {switchMap} from 'rxjs/operators';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 
 /** Path to the collection file for the NgUniversal schematics */
 export const collectionPath = require.resolve('@schematics/angular/collection.json');
 
 /** Create a base app used for testing. */
-export function createTestApp(appOptions = {}): Promise<UnitTestTree> {
+export async function createTestApp(appOptions = {}): Promise<UnitTestTree> {
   const baseRunner =
-      new SchematicTestRunner('universal-schematics', collectionPath);
+    new SchematicTestRunner('universal-schematics', collectionPath);
 
-  return baseRunner
-      .runExternalSchematicAsync('@schematics/angular', 'workspace', {
-        name: 'workspace',
-        version: '6.0.0',
-        newProjectRoot: 'projects',
-      })
-      .pipe(
-          switchMap(workspaceTree => baseRunner.runExternalSchematicAsync(
-                  '@schematics/angular', 'application',
-                  {...appOptions, name: 'test-app'}, workspaceTree)),
-      )
-      .toPromise();
+  const tree = await baseRunner.runExternalSchematicAsync('@schematics/angular', 'workspace', {
+    name: 'workspace',
+    version: '6.0.0',
+    newProjectRoot: 'projects',
+  }).toPromise();
+
+  return baseRunner.runExternalSchematicAsync(
+    '@schematics/angular', 'application',
+    {
+      ...appOptions,
+      name: 'test-app',
+    },
+    tree
+  ).toPromise();
 }

--- a/modules/express-engine/schematics/BUILD.bazel
+++ b/modules/express-engine/schematics/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
     srcs = glob(
         ["**/*.ts"],
         exclude = [
+            "testing/**/*",
             "**/*.spec.ts",
             "**/files/**/*",
         ],
@@ -55,7 +56,10 @@ jasmine_node_test(
 ng_test_library(
     name = "schematics_test_sources",
     srcs = glob(
-        ["**/*.spec.ts"],
+        [
+            "testing/*.ts",
+            "**/*.spec.ts"
+        ],
         exclude = ["**/files/**/*"],
     ),
     tsconfig = ":tsconfig.json",

--- a/modules/express-engine/schematics/BUILD.bazel
+++ b/modules/express-engine/schematics/BUILD.bazel
@@ -58,7 +58,7 @@ ng_test_library(
     srcs = glob(
         [
             "testing/*.ts",
-            "**/*.spec.ts"
+            "**/*.spec.ts",
         ],
         exclude = ["**/files/**/*"],
     ),

--- a/modules/express-engine/schematics/testing/test-app.ts
+++ b/modules/express-engine/schematics/testing/test-app.ts
@@ -6,27 +6,28 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
-import {switchMap} from 'rxjs/operators';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 
 /** Path to the collection file for the NgUniversal schematics */
 export const collectionPath = require.resolve('../collection.json');
 
 /** Create a base app used for testing. */
-export function createTestApp(appOptions = {}): Promise<UnitTestTree> {
+export async function createTestApp(appOptions = {}): Promise<UnitTestTree> {
   const baseRunner =
-      new SchematicTestRunner('universal-schematics', collectionPath);
+    new SchematicTestRunner('universal-schematics', collectionPath);
 
-  return baseRunner
-      .runExternalSchematicAsync('@schematics/angular', 'workspace', {
-        name: 'workspace',
-        version: '6.0.0',
-        newProjectRoot: 'projects',
-      })
-      .pipe(
-          switchMap(workspaceTree => baseRunner.runExternalSchematicAsync(
-                  '@schematics/angular', 'application',
-                  {...appOptions, name: 'test-app'}, workspaceTree)),
-      )
-      .toPromise();
+  const tree = await baseRunner.runExternalSchematicAsync('@schematics/angular', 'workspace', {
+    name: 'workspace',
+    version: '6.0.0',
+    newProjectRoot: 'projects',
+  }).toPromise();
+
+  return baseRunner.runExternalSchematicAsync(
+    '@schematics/angular', 'application',
+    {
+      ...appOptions,
+      name: 'test-app',
+    },
+    tree
+  ).toPromise();
 }

--- a/modules/hapi-engine/schematics/BUILD.bazel
+++ b/modules/hapi-engine/schematics/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
     srcs = glob(
         ["**/*.ts"],
         exclude = [
+            "testing/**/*",
             "**/*.spec.ts",
             "**/files/**/*",
         ],
@@ -55,7 +56,10 @@ jasmine_node_test(
 ng_test_library(
     name = "schematics_test_sources",
     srcs = glob(
-        ["**/*.spec.ts"],
+        [
+            "testing/*.ts",
+            "**/*.spec.ts"
+        ],
         exclude = ["**/files/**/*"],
     ),
     tsconfig = ":tsconfig.json",

--- a/modules/hapi-engine/schematics/BUILD.bazel
+++ b/modules/hapi-engine/schematics/BUILD.bazel
@@ -58,7 +58,7 @@ ng_test_library(
     srcs = glob(
         [
             "testing/*.ts",
-            "**/*.spec.ts"
+            "**/*.spec.ts",
         ],
         exclude = ["**/files/**/*"],
     ),

--- a/modules/hapi-engine/schematics/testing/test-app.ts
+++ b/modules/hapi-engine/schematics/testing/test-app.ts
@@ -6,27 +6,28 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
-import {switchMap} from 'rxjs/operators';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 
 /** Path to the collection file for the NgUniversal schematics */
 export const collectionPath = require.resolve('../collection.json');
 
 /** Create a base app used for testing. */
-export function createTestApp(appOptions = {}): Promise<UnitTestTree> {
+export async function createTestApp(appOptions = {}): Promise<UnitTestTree> {
   const baseRunner =
-      new SchematicTestRunner('universal-schematics', collectionPath);
+    new SchematicTestRunner('universal-schematics', collectionPath);
 
-  return baseRunner
-      .runExternalSchematicAsync('@schematics/angular', 'workspace', {
-        name: 'workspace',
-        version: '6.0.0',
-        newProjectRoot: 'projects',
-      })
-      .pipe(
-          switchMap(workspaceTree => baseRunner.runExternalSchematicAsync(
-                  '@schematics/angular', 'application',
-                  {...appOptions, name: 'test-app'}, workspaceTree)),
-      )
-      .toPromise();
+  const tree = await baseRunner.runExternalSchematicAsync('@schematics/angular', 'workspace', {
+    name: 'workspace',
+    version: '6.0.0',
+    newProjectRoot: 'projects',
+  }).toPromise();
+
+  return baseRunner.runExternalSchematicAsync(
+    '@schematics/angular', 'application',
+    {
+      ...appOptions,
+      name: 'test-app',
+    },
+    tree
+  ).toPromise();
 }


### PR DESCRIPTION

Currently we are including the testing folder in the npm_package