### PR TITLE
fix(common): use shorter name to start the ssr-dev-server

### DIFF
--- a/modules/common/schematics/add/index.spec.ts
+++ b/modules/common/schematics/add/index.spec.ts
@@ -54,7 +54,7 @@ describe('Add Schematic Rule', () => {
     const {scripts} = JSON.parse(tree.read('package.json')!.toString());
     expect(scripts['build:ssr']).toBe('ng build --prod && ng run test-app:server:production');
     expect(scripts['serve:ssr']).toBe('node dist/test-app/server/main.js');
-    expect(scripts['serve:ssr:dev']).toBe('ng run test-app:serve-ssr');
+    expect(scripts['dev:ssr']).toBe('ng run test-app:serve-ssr');
   });
 
   it('should add devDependency: @nguniversal/builders', async () => {

--- a/modules/common/schematics/add/index.ts
+++ b/modules/common/schematics/add/index.ts
@@ -60,7 +60,7 @@ function addScriptsRule(options: AddUniversalOptions): Rule {
     const pkg = JSON.parse(buffer.toString());
     pkg.scripts = {
       ...pkg.scripts,
-      'serve:ssr:dev': `ng run ${options.clientProject}:${SERVE_SSR_TARGET_NAME}`,
+      'dev:ssr': `ng run ${options.clientProject}:${SERVE_SSR_TARGET_NAME}`,
       'serve:ssr': `node ${serverDist}/main.js`,
       'build:ssr': `ng build --prod && ng run ${options.clientProject}:server:production`,
     };


### PR DESCRIPTION
Rename the npm target `serve:ssr:dev` to just `dev:ssr`