### PR TITLE
fix(common): add production config section to prerender builder config

### DIFF
--- a/modules/common/schematics/add/index.ts
+++ b/modules/common/schematics/add/index.ts
@@ -118,7 +118,12 @@ function updateWorkspaceConfigRule(options: AddUniversalOptions): Rule {
           browserTarget: `${projectName}:build:production`,
           serverTarget: `${projectName}:server:production`,
           routes: []
-        }
+        },
+        // Add a dummy production config to be consistent with other targets.
+        configurations: {
+          production: {
+          },
+        },
       });
     });
   };


### PR DESCRIPTION
This can help the firebase deploy builder(for instance) to call the either the browser build or prerender target uniformly with configuration set to production.