### PR TITLE
schematics compatible with IIS Node and Azure App service

### DIFF
--- a/integration/express-engine-ivy-prerender/server.ts
+++ b/integration/express-engine-ivy-prerender/server.ts
@@ -52,7 +52,8 @@ function run() {
 // The below code is to ensure that the server is run only when not requiring the bundle.
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
-if (mainModule && mainModule.filename === __filename) {
+const moduleFilename = mainModule && mainModule.filename || '';
+if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
   run();
 }
 

--- a/integration/express-engine-ivy/server.ts
+++ b/integration/express-engine-ivy/server.ts
@@ -52,7 +52,8 @@ function run() {
 // The below code is to ensure that the server is run only when not requiring the bundle.
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
-if (mainModule && mainModule.filename === __filename) {
+const moduleFilename = mainModule && mainModule.filename || '';
+if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
   run();
 }
 

--- a/integration/express-engine-ve/server.ts
+++ b/integration/express-engine-ve/server.ts
@@ -52,7 +52,8 @@ function run() {
 // The below code is to ensure that the server is run only when not requiring the bundle.
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
-if (mainModule && mainModule.filename === __filename) {
+const moduleFilename = mainModule && mainModule.filename || '';
+if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
   run();
 }
 

--- a/integration/hapi-engine-ivy/server.ts
+++ b/integration/hapi-engine-ivy/server.ts
@@ -58,7 +58,8 @@ async function run(): Promise<void> {
 // The below code is to ensure that the server is run only when not requiring the bundle.
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
-if (mainModule && mainModule.filename === __filename) {
+const moduleFilename = mainModule && mainModule.filename || '';
+if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
   run().catch(error => {
     console.error(`Error: ${error.toString()}`);
     process.exit(1);

--- a/integration/hapi-engine-ve/server.ts
+++ b/integration/hapi-engine-ve/server.ts
@@ -58,7 +58,8 @@ async function run(): Promise<void> {
 // The below code is to ensure that the server is run only when not requiring the bundle.
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
-if (mainModule && mainModule.filename === __filename) {
+const moduleFilename = mainModule && mainModule.filename || '';
+if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
   run().catch(error => {
     console.error(`Error: ${error.toString()}`);
     process.exit(1);

--- a/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -52,7 +52,8 @@ function run() {
 // The below code is to ensure that the server is run only when not requiring the bundle.
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
-if (mainModule && mainModule.filename === __filename) {
+const moduleFilename = mainModule && mainModule.filename || '';
+if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
   run();
 }
 

--- a/modules/hapi-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/hapi-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -58,7 +58,8 @@ async function run(): Promise<void> {
 // The below code is to ensure that the server is run only when not requiring the bundle.
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
-if (mainModule && mainModule.filename === __filename) {
+const moduleFilename = mainModule && mainModule.filename || '';
+if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
   run().catch(error => {
     console.error(`Error: ${error.toString()}`);
     process.exit(1);


### PR DESCRIPTION

The problem is that the `interceptor.js` which is used by IIS Node will require the application files rather than executing it. https://github.com/tjanczuk/iisnode/blob/8657944f8803d84514c0c7ddd48c046aa68e6edf/src/scripts/interceptor.js#L210

Thus, the server `run` method will never get invoked.