### PR TITLE
test: disable flaky ci test

### DIFF
--- a/modules/builders/src/ssr-dev-server/index.spec.ts
+++ b/modules/builders/src/ssr-dev-server/index.spec.ts
@@ -39,7 +39,10 @@ describe('Serve SSR Builder', () => {
     runs = [];
   });
 
-  it('works', async () => {
+  // todo: alan-agius4: Investigate why this tests passed locally but fails in CI.
+  // this is currenty disabled but still useful locally
+  // tslint:disable-next-line: ban
+  xit('works', async () => {
     host.writeMultipleFiles({
       'src/app/app.component.ts': `
       import { Component, Optional, Inject } from '@angular/core';


### PR DESCRIPTION
While this works locally, on ci this is causing 90% of our builds to be red,.