### PR TITLE
fix(builders): default to a minimum of 1 CPU when sharding builds

### DIFF
--- a/modules/builders/src/prerender/utils.ts
+++ b/modules/builders/src/prerender/utils.ts
@@ -56,7 +56,7 @@ export async function getRoutes(
  * Evenly shards items in an array.
  * e.g. shardArray([1, 2, 3, 4], 2) => [[1, 2], [3, 4]]
  */
-export function shardArray<T>(items: T[], maxNoOfShards = os.cpus().length - 1): T[][] {
+export function shardArray<T>(items: T[], maxNoOfShards = (os.cpus().length - 1) || 1): T[][] {
   const shardedArray = [];
   const numShards = Math.min(maxNoOfShards, items.length);
   for (let i = 0; i < numShards; i++) {


### PR DESCRIPTION
Closes #1466