### PR TITLE
fix(builders): only remove reload script leading slash when having a …

### DIFF
--- a/modules/builders/src/ssr-dev-server/index.ts
+++ b/modules/builders/src/ssr-dev-server/index.ts
@@ -234,8 +234,6 @@ async function initBrowserSync(
     ghostMode: false,
     logLevel: 'silent',
     open,
-    // Remove leading slash
-    scriptPath: path => path.substring(1),
   };
 
   const publicHostNormalized = publicHost && publicHost.endsWith('/')
@@ -265,6 +263,8 @@ async function initBrowserSync(
     // However users will typically have a reverse proxy that will redirect all matching requests
     // ex: http://testinghost.com/ssr -> http://localhost:4200 which will result in a 404.
     if (hasPathname) {
+      // Remove leading slash
+      bsOptions.scriptPath = p => p.substring(1),
       bsOptions.middleware = [
         proxy(defaultSocketIoPath, {
           target: url.format({


### PR DESCRIPTION
…public host with a path name

We should only remove the leading slash of BrowserSync script when having a public host with a path name, this will other cause the browser sync script not to be found when using a base href.

Closes #1495