### PR TITLE
build: Change --symlink_prefix to dist/

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@
 # https://github.com/bazelbuild/rules_typescript/issues/12 which affects the common case of
 # having `tsconfig.json` in the WORKSPACE directory. Instead, you should run
 # `bazel info output_base` to find out where the outputs went.
-build --symlink_prefix=/
+build --symlink_prefix=dist/
 
 # Performance: avoid stat'ing input files
 build --watchfs


### PR DESCRIPTION
`--symlink_prefix=/` will not generate `bazel-out` in the repository,
which would cause the npm_package.publish script to fail, since it looks
for the `bazel-out` directory to find package directory and package.json