### PR TITLE
fix: ng update showing packages that do not exist in my package

### DIFF
--- a/modules/aspnetcore-engine/package.json
+++ b/modules/aspnetcore-engine/package.json
@@ -26,7 +26,8 @@
     "tslib": "TSLIB_VERSION"
   },
   "ng-update": {
-    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP",
+    "packageGroupName": "@nguniversal/aspnetcore-engine"
   },
   "repository": {
     "type": "git",

--- a/modules/builders/package.json
+++ b/modules/builders/package.json
@@ -21,8 +21,5 @@
     "rxjs": "RXJS_VERSION",
     "tree-kill": "^1.2.1",
     "guess-parser": "^0.4.12"
-  },
-  "ng-update": {
-    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/modules/common/package.json
+++ b/modules/common/package.json
@@ -16,7 +16,8 @@
     "tslib": "TSLIB_VERSION"
   },
   "ng-update": {
-    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP",
+    "packageGroupName": "@nguniversal/common"
   },
   "repository": {
     "type": "git",

--- a/modules/express-engine/package.json
+++ b/modules/express-engine/package.json
@@ -24,7 +24,8 @@
   "schematics": "./schematics/collection.json",
   "ng-update": {
     "migrations": "./schematics/migrations/migration-collection.json",
-    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP",
+    "packageGroupName": "@nguniversal/express-engine"
   },
   "repository": {
     "type": "git",

--- a/modules/hapi-engine/package.json
+++ b/modules/hapi-engine/package.json
@@ -24,7 +24,8 @@
   "schematics": "./schematics/collection.json",
   "ng-update": {
     "migrations": "./schematics/migrations/migration-collection.json",
-    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP",
+    "packageGroupName": "@nguniversal/hapi-engine"
   },
   "repository": {
     "type": "git",

--- a/modules/socket-engine/package.json
+++ b/modules/socket-engine/package.json
@@ -17,7 +17,8 @@
     "tslib": "TSLIB_VERSION"
   },
   "ng-update": {
-    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP",
+    "packageGroupName": "@nguniversal/socket-engine"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
By default if no `packageGroupName` is provided `ng-update` will use the first item in `packageGroup` which in this case it is always `@nguniversal/aspnetcore-engine`.

With this change we set the `packageGroupName` of each package, also we remove `ng-update` from `@nguniversal/builders` as this gets updated when running `ng update` on `@nguniversal/express-engine`  or `@nguniversal/hapi-engine`.

Closes #1542 and closes #1533