### PR TITLE
chore: Improve prerender logging

### DIFF
--- a/modules/builders/src/prerender/utils.ts
+++ b/modules/builders/src/prerender/utils.ts
@@ -45,10 +45,12 @@ export async function getRoutes(
             .filter(route => !route.includes('*') && !route.includes(':'))
         );
       } catch (e) {
-        context.logger.error('Unable to extract routes from application.', e);
+        context.logger.error('Unable to guess the routes from application.', e);
       }
     }
   }
+  
+  context.logger.info(`Found routes: ${routes.join(', ')}`);
 
   return [...new Set(routes)];
 }

--- a/modules/builders/src/prerender/utils.ts
+++ b/modules/builders/src/prerender/utils.ts
@@ -49,7 +49,7 @@ export async function getRoutes(
       }
     }
   }
-  
+
   context.logger.info(`Found routes: ${routes.join(', ')}`);
 
   return [...new Set(routes)];


### PR DESCRIPTION
When debugging prerender issues, its often difficult to tell which routes have actually been found.
It seem prudent just to log the routes here.