### PR TITLE
feat(builders): add `--inspect` option to `ssr-dev-server` builder

### DIFF
--- a/modules/builders/src/ssr-dev-server/schema.json
+++ b/modules/builders/src/ssr-dev-server/schema.json
@@ -37,6 +37,11 @@
     "progress": {
       "type": "boolean",
       "description": "Log progress to the console while building."
+    },
+    "inspect": {
+      "type": "boolean",
+      "description": "Launch the development server in inspector mode and listen on address and port '127.0.0.1:9229'.",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Wiith this change we add the ability to inspect the server code when running the ssr-dev-server. We launch the development server in inspector mode on address and port `127.0.0.1:9229`.

Note: the debugger will need to be attached on every incremental build, since the Node process is restarted each time.

Closes #1624