### PR TITLE
fix(express-engine): use response in request object if not provided

### DIFF
--- a/modules/express-engine/spec/index.spec.ts
+++ b/modules/express-engine/spec/index.spec.ts
@@ -6,6 +6,7 @@ import { SOME_TOKEN } from '../testing/mock.server.module';
 import {
   MockServerModuleNgFactory,
   RequestServerModuleNgFactory,
+  ResponseServerModuleNgFactory,
   TokenServerModuleNgFactory
 } from '../testing/mock.server.module.ngfactory';
 
@@ -49,6 +50,27 @@ describe('test runner', () => {
         throw err;
       }
       expect(html).toContain('url:http://localhost:4200');
+      done();
+    });
+  });
+
+  it('should be able to inject RESPONSE token', (done) => {
+    const someStatusCode = 400;
+    ngExpressEngine({bootstrap: ResponseServerModuleNgFactory})(null as any as string, {
+      req: {
+        get: () => 'localhost',
+        res : {
+          statusCode: someStatusCode
+        }
+      } as any,
+      // TODO this shouldn't be required
+      bootstrap: ResponseServerModuleNgFactory,
+      document: '<root></root>'
+    }, (err, html) => {
+      if (err) {
+        throw err;
+      }
+      expect(html).toContain(`statusCode:${someStatusCode}`);
       done();
     });
   });

--- a/modules/express-engine/src/main.ts
+++ b/modules/express-engine/src/main.ts
@@ -50,6 +50,7 @@ export function ngExpressEngine(setupOptions: Readonly<NgSetupOptions>) {
       }
 
       const req = options.req;
+      const res = options.res || req.res;
 
       const renderOptions: RenderOptions = Object.assign({}, options);
 
@@ -58,8 +59,7 @@ export function ngExpressEngine(setupOptions: Readonly<NgSetupOptions>) {
       renderOptions.document = options.document || getDocument(filePath);
 
       renderOptions.providers = options.providers || [];
-      renderOptions.providers =
-        renderOptions.providers.concat(getReqResProviders(options.req, options.res));
+      renderOptions.providers = renderOptions.providers.concat(getReqResProviders(req, res));
 
       engine.render(renderOptions)
         .then(html => callback(null, html))

--- a/modules/express-engine/testing/mock.server.module.ts
+++ b/modules/express-engine/testing/mock.server.module.ts
@@ -8,7 +8,7 @@
 import { Component, Inject, InjectionToken, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { ServerModule } from '@angular/platform-server';
-import { REQUEST } from '@nguniversal/express-engine/tokens';
+import { REQUEST, RESPONSE } from '@nguniversal/express-engine/tokens';
 
 @Component({selector: 'root', template: 'some template'})
 export class MockComponent {
@@ -33,6 +33,19 @@ export class RequestComponent {
   bootstrap: [RequestComponent],
 })
 export class RequestServerModule {
+}
+
+@Component({selector: 'root', template: `statusCode:{{_res.statusCode}}`})
+export class ResponseComponent {
+  constructor(@Inject(RESPONSE) public readonly _res: any) {}
+}
+
+@NgModule({
+  imports: [BrowserModule.withServerTransition({appId: 'mock'}), ServerModule],
+  declarations: [ResponseComponent],
+  bootstrap: [ResponseComponent],
+})
+export class ResponseServerModule {
 }
 
 export const SOME_TOKEN = new InjectionToken<string>('SOME_TOKEN');


### PR DESCRIPTION
The default implementation of the Express server does not pass the `res` render option to the engine. In this case, fallback to use the response stored in Express' request object.

Closes #1691