### PR TITLE
build: remove dev dependency on @types/express-serve-static-core

### DIFF
--- a/modules/express-engine/tokens/BUILD.bazel
+++ b/modules/express-engine/tokens/BUILD.bazel
@@ -13,6 +13,5 @@ ng_module(
     deps = [
         "@npm//@angular/core",
         "@npm//@types/express",
-        "@npm//@types/express-serve-static-core",
     ],
 )

--- a/modules/express-engine/tokens/injection-tokens.ts
+++ b/modules/express-engine/tokens/injection-tokens.ts
@@ -7,7 +7,6 @@
  */
 import { InjectionToken } from '@angular/core';
 import { Request, Response } from 'express';
-import { ParamsDictionary } from 'express-serve-static-core';
 
-export const REQUEST = new InjectionToken<Request<ParamsDictionary>>('REQUEST');
-export const RESPONSE = new InjectionToken<Response>('RESPONSE');
+export const REQUEST: InjectionToken<Request> = new InjectionToken<Request>('REQUEST');
+export const RESPONSE: InjectionToken<Response> = new InjectionToken<Response>('RESPONSE');

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@schematics/angular": "^10.0.0-rc.0",
     "@types/browser-sync": "^2.26.1",
     "@types/express": "4.17.6",
-    "@types/express-serve-static-core": "4.17.7",
     "@types/fs-extra": "^9.0.0",
     "@types/hapi__hapi": "^19.0.0",
     "@types/hapi__inert": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,15 +1556,6 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express-serve-static-core@4.17.7":
-  version "4.17.7"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz#dfe61f870eb549dc6d7e12050901847c7d7e915b"
-  integrity sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-
 "@types/express@4.17.6":
   version "4.17.6"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.6.tgz#6bce49e49570507b86ea1b07b806f04697fac45e"


### PR DESCRIPTION
@types/express-serve-static-core is now a direct dependency of
@types/express, and having both creates TypeScript conflicts.