### PR TITLE
build: embed tslib in umd bundles

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -80,7 +80,6 @@ GLOBALS = {
     "@hapi/hapi": "hapi.hapi",
     "rxjs": "rxjs",
     "rxjs/operators": "rxjs.operators",
-    "tslib": "tslib",
 }
 
 def ng_module(name, tsconfig = None, testonly = False, deps = [], bundle_dts = True, **kwargs):
@@ -127,10 +126,12 @@ def ng_test_library(deps = [], tsconfig = None, **kwargs):
         **kwargs
     )
 
-def ng_package(globals = {}, **kwargs):
+def ng_package(globals = {}, deps = [], **kwargs):
     globals = dict(globals, **GLOBALS)
-
-    _ng_package(globals = globals, substitutions = PKG_GROUP_REPLACEMENTS, **kwargs)
+    deps = deps + [
+        "@npm//tslib",
+    ]
+    _ng_package(globals = globals, deps = deps, substitutions = PKG_GROUP_REPLACEMENTS, **kwargs)
 
 def pkg_npm(name, substitutions = {}, **kwargs):
     _pkg_npm(


### PR DESCRIPTION
When tslib is listed as part of the globals, it will not be embedded in the UMD bundles.
https://github.com/angular/angular/blob/fd65958b887f6ea8dd5235e6de1d533e4c578602/packages/bazel/src/ng_package/ng_package.bzl#L226-L228

Users using UMD bundles, shouldn't be needing to add the tslib script, also this is important because tslib is a direct depedency of the package and not a peer depedency.

This is also to align with the Angular FW packages.