### PR TITLE
Update transfer_http.ts

### DIFF
--- a/modules/common/spec/transfer_http.spec.ts
+++ b/modules/common/spec/transfer_http.spec.ts
@@ -36,5 +36,11 @@ describe('TransferHttp', () => {
         new HttpParams().append('b', 'foo').append('a', 'bar'));
       expect(key1).toEqual(key2);
     });
+    it('should encode arrays in url params', () => {
+      const interceptor = new TransferHttpCacheInterceptor(mockAppRef(), mockTransferState());
+      const key = interceptor['makeCacheKey']('GET', 'https://google.com/api',
+        new HttpParams().append('b', 'xyz').append('a', 'foo').append('a', 'bar'));
+      expect(key).toEqual('G.https://google.com/api?a=foo,bar&b=xyz');
+    });
   });
 });

--- a/modules/common/src/transfer_http.ts
+++ b/modules/common/src/transfer_http.ts
@@ -54,7 +54,7 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
 
   private makeCacheKey(method: string, url: string, params: HttpParams): StateKey<string> {
     // make the params encoded same as a url so it's easy to identify
-    const encodedParams = params.keys().sort().map(k => `${k}=${params.get(k)}`).join('&');
+    const encodedParams = params.keys().sort().map(k => `${k}=${params.getAll(k)}`).join('&');
     const key = (method === 'GET' ? 'G.' : 'H.') + url + '?' + encodedParams;
 
     return makeStateKey<TransferHttpResponse>(key);


### PR DESCRIPTION
caching GET request with query string with array of parameter gets the first value only.
it breaks caching for the same url with different query string for example
for api http://api.example.com?params=1&params=2&params=3 cache key will be http://api.example.com?params=1
for api http://api.example.com?params=1&params=2 cache key will be the same http://api.example.com?params=1
and therefor API request will not be sent to server.