### PR TITLE
build: remove --experimental_allow_incremental_repository_updates in …

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -70,10 +70,6 @@ build --define=compile=legacy
 # These settings are required for rules_nodejs
 ###############################
 
-# Turn on managed directories feature in Bazel
-# This allows us to avoid installing a second copy of node_modules
-common --experimental_allow_incremental_repository_updates
-
 # Turn on --incompatible_strict_action_env which was on by default
 # in Bazel 0.21.0 but turned off again in 0.22.0. Follow
 # https://github.com/bazelbuild/bazel/issues/7026 for more details.


### PR DESCRIPTION
…bazelrc

Managed directories is no longer an experimental feature, so the flag is
no longer needed in .bazelrc.