### PR TITLE
build: update tslint rules to remove usage of whitelist in comments

### DIFF
--- a/tools/tslint-rules/noRxjsPatchImportsRule.ts
+++ b/tools/tslint-rules/noRxjsPatchImportsRule.ts
@@ -7,7 +7,7 @@ const ERROR_MESSAGE = 'Uses of RxJS patch imports are forbidden.';
 
 /**
  * Rule that prevents uses of RxJS patch imports (e.g. `import 'rxjs/add/operator/map').
- * Supports whitelisting via `"no-patch-imports": [true, "\.spec\.ts$"]`.
+ * Supports allowing usage in specific filesvia `"no-patch-imports": [true, "\.spec\.ts$"]`.
  */
 export class Rule extends Lint.Rules.AbstractRule {
   apply(sourceFile: ts.SourceFile) {


### PR DESCRIPTION
Remove usage of the term whitelist in commenting for noRxjsPatchImportsRule