### PR TITLE
feat: enable absolute URL handling by default for all engines

### DIFF
--- a/modules/common/engine/src/engine.ts
+++ b/modules/common/engine/src/engine.ts
@@ -49,7 +49,8 @@ export class CommonEngine {
         provide: INITIAL_CONFIG,
         useValue: {
           document: doc,
-          url: opts.url
+          url: opts.url,
+          useAbsoluteUrl: true,
         }
       }
     ];


### PR DESCRIPTION
This functionality was added in Angular v10.1 as an opt-in for
all users. Since ngExpressEngine and ngHapiEngine are meant to
enable best practices out of the box, we enable this for users
by default as well.