### PR TITLE
Updated the express engine to use the absolute url flag

### DIFF
--- a/modules/common/engine/src/engine.ts
+++ b/modules/common/engine/src/engine.ts
@@ -49,7 +49,8 @@ export class CommonEngine {
         provide: INITIAL_CONFIG,
         useValue: {
           document: doc,
-          url: opts.url
+          url: opts.url,
+          useAbsoluteUrl: true,
         }
       }
     ];


### PR DESCRIPTION
Flag is defined [here](https://github.com/CaerusKaru/angular/blob/98c047b76360218e0b910298416eb1c56b56f163/packages/platform-server/src/tokens.ts#L35). [Background](https://github.com/angular/angular/pull/37539).

The docs [here](https://angular.io/guide/universal#using-absolute-urls-for-http-data-requests-on-the-server) mention that it's handled automatically, but it does seem to work without this flag.