### PR TITLE
fix(builders): improve prerendering logging

### DIFF
--- a/modules/builders/BUILD.bazel
+++ b/modules/builders/BUILD.bazel
@@ -30,6 +30,7 @@ ts_library(
         "@npm//browser-sync",
         "@npm//guess-parser",
         "@npm//http-proxy-middleware",
+        "@npm//ora",
         "@npm//rxjs",
         "@npm//tree-kill",
     ],

--- a/modules/builders/package.json
+++ b/modules/builders/package.json
@@ -25,9 +25,10 @@
     "@angular-devkit/architect": "DEVKIT_ARCHITECT_VERSION",
     "@angular-devkit/core": "DEVKIT_CORE_VERSION",
     "browser-sync": "^2.26.7",
+    "guess-parser": "^0.4.12",
     "http-proxy-middleware": "^1.0.0",
+    "ora": "^5.1.0",
     "rxjs": "RXJS_VERSION",
-    "tree-kill": "^1.2.1",
-    "guess-parser": "^0.4.12"
+    "tree-kill": "^1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "jasmine-core": "^3.6.0",
     "minimatch": "^3.0.4",
     "node-fetch": "^2.6.1",
+    "ora": "^5.1.0",
     "protractor": "7.0.0",
     "puppeteer": "5.4.1",
     "rollup": "~2.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7249,7 +7249,7 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
-ora@5.1.0:
+ora@5.1.0, ora@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-5.1.0.tgz#b188cf8cd2d4d9b13fd25383bc3e5cba352c94f8"
   integrity sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==


### PR DESCRIPTION
With this change we improve the prerender logging by:
- Reduce the verbosity of the logs when generating route
- Improve logs when an error occuries
- Add a spinner

Closes #1844