### PR TITLE
fix: remove extractCss from ssr-dev-server builder

### DIFF
--- a/integration/express-engine-ivy-prerender/angular.json
+++ b/integration/express-engine-ivy-prerender/angular.json
@@ -67,7 +67,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,

--- a/integration/express-engine-ivy/angular.json
+++ b/integration/express-engine-ivy/angular.json
@@ -64,7 +64,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,

--- a/integration/express-engine-ve/angular.json
+++ b/integration/express-engine-ve/angular.json
@@ -64,7 +64,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,

--- a/integration/hapi-engine-ivy/angular.json
+++ b/integration/hapi-engine-ivy/angular.json
@@ -64,7 +64,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,

--- a/integration/hapi-engine-ve/angular.json
+++ b/integration/hapi-engine-ve/angular.json
@@ -64,7 +64,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,

--- a/modules/builders/src/ssr-dev-server/index.ts
+++ b/modules/builders/src/ssr-dev-server/index.ts
@@ -64,7 +64,6 @@ export function execute(
   const getBaseUrl = (bs: browserSync.BrowserSyncInstance) => `${bs.getOption('scheme')}://${bs.getOption('host')}:${bs.getOption('port')}`;
 
   const browserTargetRun = context.scheduleTarget(browserTarget, {
-    extractCss: true,
     serviceWorker: false,
     watch: true,
     progress: options.progress,

--- a/modules/builders/testing/hello-world-app/angular.json
+++ b/modules/builders/testing/hello-world-app/angular.json
@@ -45,7 +45,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,


### PR DESCRIPTION
As of Angular CLI version 11, extractCss is deprecated and is now done by default.