### PR TITLE
fix(hapi-engine): ng-add schematic

### DIFF
--- a/modules/hapi-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/hapi-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -9,7 +9,7 @@ import { readFileSync, existsSync } from 'fs';
 import { AppServerModule } from './src/<%= stripTsExtension(main) %>';
 
 // The Hapi server is exported so that it can be used by serverless functions.
-export async function app(): Promise<void> {
+export async function app(): Promise<Server> {
   const port = process.env.PORT || <%= serverPort %>;
   const distFolder = join(process.cwd(), '<%= browserDistDirectory %>');
   const server = new Server({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type: Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Right now when you generate a Angular CLI project and then add the hapi-engine and run it like

```
$ ng add @nguniversal/hapi-engine
$ ng run ngssr:serve-ssr
```

it fails due to a TS error.

Issue Number: N/A


## What is the new behavior?

Fixes the schematic by solving the TS error

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information