### PR TITLE
feat: add hybrid rendering support

### DIFF
--- a/integration/hapi-engine-ivy/server.ts
+++ b/integration/hapi-engine-ivy/server.ts
@@ -23,15 +23,29 @@ export async function app() {
 
   const indexHtml = existsSync(join(distFolder, 'index.original.html')) ? 'index.original.html' : 'index.html';
   const document = readFileSync(join(distFolder, indexHtml), 'utf-8');
+  const pageExists = new Map<string, boolean>();
 
   server.route({
     method: 'GET',
     path: '/{path*}',
-    handler: (req: Request) => ngHapiEngine({
-      bootstrap: AppServerModule,
-      document,
-      req,
-    })
+    handler: (req: Request, res: ResponseToolkit) => {
+      const htmlPath = join(distFolder, req.path, 'index.html');
+      // Check if the page is already prerendered.
+      // To avoid extra disk I/O operation in the future remember if the file exists
+      if (!pageExists.has(req.path)) {
+        pageExists.set(req.path, existsSync(htmlPath));
+      }
+      if (pageExists.get(req.path)) {
+        return res.file(htmlPath);
+      }
+      // Server-side rendering
+
+      return ngHapiEngine({
+        bootstrap: AppServerModule,
+        document,
+        req,
+      });
+    }
   });
 
   await server.register(inert);


### PR DESCRIPTION
This change adds hybrid rendering support, which allows serving both:
- Server-side rendered pages
- Prerendered pages if they already exist

To avoid extra disk I/O operations, in both engine there's a
`pageExists` set that caches if the prerendered page exists. This way
on subsequent calls we'd be able to avoid the `existsSync` call, which
is on the critical path for serving SSR and prerendered pages.

Why not cache the entire page? Mostly to reduce memory consumption.
In apps with thousands of prerendered pages, this could cause server
crash. Also, in-memory cache might not be the most suitable for
autoscaling with multiple server instances.