### PR TITLE
build: set minimum Node.js version to 12.13

### DIFF
--- a/modules/aspnetcore-engine/package.json
+++ b/modules/aspnetcore-engine/package.json
@@ -17,7 +17,7 @@
     "universal"
   ],
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.13.0"
   },
   "dependencies": {
     "domino": "^2.1.6",

--- a/modules/builders/package.json
+++ b/modules/builders/package.json
@@ -4,6 +4,9 @@
   "description": "Angular Universal builders package",
   "homepage": "https://github.com/angular/universal#readme",
   "license": "MIT",
+  "engines": {
+    "node": ">=12.13.0"
+  },
   "keywords": [
     "ssr",
     "universal",

--- a/modules/common/package.json
+++ b/modules/common/package.json
@@ -8,7 +8,7 @@
     "universal"
   ],
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.13.0"
   },
   "dependencies": {
     "critters": "0.0.6",

--- a/modules/express-engine/package.json
+++ b/modules/express-engine/package.json
@@ -9,7 +9,7 @@
     "universal"
   ],
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.13.0"
   },
   "peerDependencies": {
     "@angular/common": "NG_VERSION",

--- a/modules/hapi-engine/package.json
+++ b/modules/hapi-engine/package.json
@@ -9,7 +9,7 @@
     "universal"
   ],
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.13.0"
   },
   "peerDependencies": {
     "@angular/common": "NG_VERSION",

--- a/modules/socket-engine/package.json
+++ b/modules/socket-engine/package.json
@@ -9,7 +9,7 @@
     "universal"
   ],
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.13.0"
   },
   "dependencies": {
     "tslib": "TSLIB_VERSION"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "engine-strict": true
   },
   "engines": {
-    "node": ">=10.13.0 <13.0.0",
+    "node": ">=12.13.0 <15.0.0",
     "yarn": ">=1.0.0"
   },
   "scripts": {

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,9 @@
   "baseBranches": [
     "master"
   ],
+  "ignoreDeps": [
+    "@types/node"
+  ],
   "packageFiles": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
BREAKING CHANGE:
Node.js version 10 will become EOL on 2021-04-30.
Angular CLI 12 will require Node.js 12.13+ or 14.15+. Node.js 12.13 and 14.15 are the first LTS releases for their respective majors.