### PR TITLE
feat(@nguniversal/builders) add SSL support for dev-server

### DIFF
--- a/modules/builders/src/ssr-dev-server/index.spec.ts
+++ b/modules/builders/src/ssr-dev-server/index.spec.ts
@@ -8,9 +8,9 @@
 
 import { Architect, BuilderRun } from '@angular-devkit/architect';
 import * as browserSync from 'browser-sync';
-import { concatMap, debounceTime, mergeMap, retryWhen, take } from 'rxjs/operators';
-
+import * as https from 'https';
 import { from, throwError, timer } from 'rxjs';
+import { concatMap, debounceTime, mergeMap, retryWhen, take } from 'rxjs/operators';
 import { createArchitect, host } from '../../testing/utils';
 import { SSRDevServerBuilderOutput } from './index';
 
@@ -88,6 +88,20 @@ describe('Serve SSR Builder', () => {
     const output = await run.result as SSRDevServerBuilderOutput;
     expect(output.success).toBe(true);
     expect(output.baseUrl).not.toContain('4200');
+  });
+
+  it('works with SSL', async () => {
+    const run = await architect.scheduleTarget(target, { ssl: true });
+    runs.push(run);
+    const output = await run.result as SSRDevServerBuilderOutput;
+    expect(output.success).toBe(true);
+    expect(output.baseUrl).toBe('https://localhost:4200');
+
+    const response = await fetch('https://localhost:4200/index.html', {
+      agent: new https.Agent({ rejectUnauthorized: false }),
+    });
+
+    expect(await response.text()).toContain('<title>App</title>');
   });
 
   // todo: alan-agius4: Investigate why this tests passed locally but fails in CI.

--- a/modules/builders/src/ssr-dev-server/schema.json
+++ b/modules/builders/src/ssr-dev-server/schema.json
@@ -42,6 +42,19 @@
       "type": "boolean",
       "description": "Launch the development server in inspector mode and listen on address and port '127.0.0.1:9229'.",
       "default": false
+    },
+    "ssl": {
+      "type": "boolean",
+      "description": "Serve using HTTPS.",
+      "default": false
+    },
+    "sslKey": {
+      "type": "string",
+      "description": "SSL key to use for serving HTTPS."
+    },
+    "sslCert": {
+      "type": "string",
+      "description": "SSL certificate to use for serving HTTPS."
     }
   },
   "additionalProperties": false,

--- a/modules/builders/src/ssr-dev-server/schema.ts
+++ b/modules/builders/src/ssr-dev-server/schema.ts
@@ -33,4 +33,13 @@ export interface Schema {
    * Use for a complex dev server setup, such as one with reverse proxies.
    */
   publicHost?: string;
+
+  /** Serve using HTTPS. */
+  ssl?: boolean;
+
+  /** SSL key to use for serving HTTPS. */
+  sslKey?: string;
+
+  /** SSL certificate to use for serving HTTPS. */
+  sslCert?: string;
 }


### PR DESCRIPTION
With this change we add SSL support to the SSR dev-server. We expose 3 new options;

- `ssl`: Turn on/off HTTPs
- `sslKey`: SSL key to use for serving HTTPS
- `sslCert`: SSL certificate to use for serving HTTPS

Closes #1633