### PR TITLE
fix(@nguniversal/common): inline critical font-face rules when using critical css inlining

### DIFF
--- a/modules/builders/src/prerender/index.ts
+++ b/modules/builders/src/prerender/index.ts
@@ -130,8 +130,8 @@ async function _renderUniversal(
               serverBundlePath,
               outputPath,
               browserOptions.deployUrl || '',
-              normalizedStylesOptimization.inlineCritical === true ? 'true' : 'false' ,
-              normalizedStylesOptimization.minify === true ? 'true' : 'false' ,
+              normalizedStylesOptimization.inlineCritical ? 'true' : 'false' ,
+              normalizedStylesOptimization.minify ? 'true' : 'false' ,
               ...routesShard,
             ])
               .on('message', data => {

--- a/modules/common/engine/src/inline-css-processor.ts
+++ b/modules/common/engine/src/inline-css-processor.ts
@@ -40,6 +40,7 @@ class CrittersExtended extends Critters {
       mergeStylesheets: false,
       preload: 'media',
       noscriptFallback: true,
+      inlineFonts: true,
       // Cast any is needed because of logger API is not exposed as part of the options
       // https://github.com/GoogleChromeLabs/critters/issues/66
       // tslint:disable-next-line: no-any


### PR DESCRIPTION

When critical font rules are not inlined it will cause blinking as during first render the fallback font will be rendered.

Closes #2002