### PR TITLE
browser directory not getting created without application name in ssr…

### DIFF
--- a/modules/common/schematics/add/index.ts
+++ b/modules/common/schematics/add/index.ts
@@ -72,7 +72,7 @@ function addScriptsRule(options: AddUniversalOptions): Rule {
       ...pkg.scripts,
       'dev:ssr': `ng run ${options.clientProject}:${SERVE_SSR_TARGET_NAME}`,
       'serve:ssr': `node ${serverDist}/main.js`,
-      'build:ssr': `ng build && ng run ${options.clientProject}:server`,
+      'build:ssr': `ng build ${options.clientProject} && ng run ${options.clientProject}:server`,
       'prerender': `ng run ${options.clientProject}:${PRERENDER_TARGET_NAME}`,
     };
 


### PR DESCRIPTION
`build:ssr` script need client application name. without client application name its only creating server directory on build.
