### PR TITLE
feat(@nguniversal/builders): add support for proxy configuration in ssr-dev-server

### DIFF
--- a/modules/builders/src/ssr-dev-server/schema.json
+++ b/modules/builders/src/ssr-dev-server/schema.json
@@ -55,6 +55,10 @@
     "sslCert": {
       "type": "string",
       "description": "SSL certificate to use for serving HTTPS."
+    },
+    "proxyConfig": {
+      "type": "string",
+      "description": "Proxy configuration file."
     }
   },
   "additionalProperties": false,

--- a/modules/builders/src/ssr-dev-server/schema.ts
+++ b/modules/builders/src/ssr-dev-server/schema.ts
@@ -42,4 +42,7 @@ export interface Schema {
 
   /** SSL certificate to use for serving HTTPS. */
   sslCert?: string;
+
+  /** Proxy configuration file */
+  proxyConfig?: string;
 }

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -106,6 +106,7 @@ def jasmine_node_test(deps = [], **kwargs):
 
     _jasmine_node_test(
         deps = local_deps,
+        templated_args = ["--bazel_patch_module_resolver"],
         configuration_env_vars = ["compile"],
         **kwargs
     )


### PR DESCRIPTION


With this change we added a new `proxyConfig` option to be used to provide custom proxy configurations to the ssr-dev-server builder.

Closes #1757