### PR TITLE
ci: remove `commitMessage` from Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "pinVersions": false,
   "semanticCommits": true,
   "semanticPrefix": "build",
-  "commitMessage": "{{semanticPrefix}} update {{#if groupName}}{{{groupName}}} packages{{else}}{{{depName}}} to version {{{newVersion}}}{{/if}}",
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
   "labels": [


### PR DESCRIPTION
Renovate creates better commit message.