### PR TITLE
fix(common): add `serverTarget` for prerender

### DIFF
--- a/modules/express-engine/schematics/install/index.ts
+++ b/modules/express-engine/schematics/install/index.ts
@@ -118,9 +118,11 @@ function updateWorkspaceConfigRule(options: AddUniversalOptions): Rule {
         configurations: {
           production: {
             browserTarget: `${options.project}:build:production`,
+            serverTarget: `${projectName}:server:production`,
           },
           development: {
             browserTarget: `${options.project}:build:development`,
+            serverTarget: `${projectName}:server:development`,
           },
         },
       });


### PR DESCRIPTION
Add `serverTarget` for the prerender architect in the add schematic

Closes #2120