### PR TITLE
refactor(express-engine): use `projectName` for prerender

### DIFF
--- a/modules/express-engine/schematics/install/index.ts
+++ b/modules/express-engine/schematics/install/index.ts
@@ -117,11 +117,11 @@ function updateWorkspaceConfigRule(options: AddUniversalOptions): Rule {
         },
         configurations: {
           production: {
-            browserTarget: `${options.project}:build:production`,
+            browserTarget: `${projectName}:build:production`,
             serverTarget: `${projectName}:server:production`,
           },
           development: {
-            browserTarget: `${options.project}:build:development`,
+            browserTarget: `${projectName}:build:development`,
             serverTarget: `${projectName}:server:development`,
           },
         },


### PR DESCRIPTION
Use the `projectName` variable in the prerender architect.

I used the `projectName` variable to be consistent with the `ssr-dev-server` architect.