### PR TITLE
docs: add a link of the contributing guidelines to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Angular Universal project is a community driven project to expand on the cor
 
 This repository will host the various tools like engines to integrate with various backends(NodeJS, ASP.NET etc.) and also extra modules and examples to help you started with server side rendering.
 
-The Universal project is driven by community contributions. Please send us your Pull Requests!
+The Universal project is driven by community contributions. Please check [our contributing guidelines](https://github.com/angular/universal/blob/master/CONTRIBUTING.md) and send us your Pull Requests!
 
 # Getting Started
 


### PR DESCRIPTION
---
name: ⚙ Improvement
about: You have made an improvement to Angular Universal
---

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type:  improve documentation


## What is the current behavior?
There is no link to the contributing guidelines in the README.

I think it would be better to have a link to the Contributing guidelines in the README, just like in other Angular Organization repositories.

## What is the new behavior?
There is a link to the contributing guidelines in the README.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information