### PR TITLE
feat(@nguniversal/builders): spawn static server for build artifacts

### DIFF
--- a/integration/clover/src/app/app.module.ts
+++ b/integration/clover/src/app/app.module.ts
@@ -20,7 +20,10 @@ import { PokedexComponent } from './pokedex.component';
     // The HttpClientInMemoryWebApiModule module intercepts HTTP requests
     // and returns simulated server responses.
 
-    HttpClientInMemoryWebApiModule.forRoot(PokemonService, { dataEncapsulation: false }),
+    HttpClientInMemoryWebApiModule.forRoot(PokemonService, {
+      dataEncapsulation: false,
+      passThruUnknownUrl: true,
+    }),
 
     RendererModule.forRoot(),
     TransferHttpCacheModule,

--- a/integration/clover/src/app/homepage.component.ts
+++ b/integration/clover/src/app/homepage.component.ts
@@ -1,11 +1,21 @@
+import { HttpClient } from '@angular/common/http';
 import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-homepage',
-  template: ` <p>Welcome to {{ title }}!</p> `,
+  template: ` <p>Welcome to {{ title }}!</p>
+    <p>{{ message$ | async }}</p>`,
   styles: [],
 })
 export class HomepageComponent {
   title = 'Pokemon';
-  constructor() {}
+
+  message$: Observable<string>;
+  constructor(http: HttpClient) {
+    this.message$ = http
+      .get<{ message: string }>('assets/data.json')
+      .pipe(map((data) => data.message));
+  }
 }

--- a/integration/clover/src/assets/data.json
+++ b/integration/clover/src/assets/data.json
@@ -1,0 +1,3 @@
+{
+  "message": "Lorem ipsum dolor sit amet."
+}

--- a/integration/clover/test.js
+++ b/integration/clover/test.js
@@ -21,4 +21,12 @@ for (const page of pages) {
   if (!content.includes('ng-clover')) {
     throw new Error(`Page ${page} didn't contain ng-clover marker.`);
   }
+
+  // Asserts embedded state transfer for local relative requests
+  if (page === 'index.html') {
+    const dataJson = require('./src/assets/data.json');
+    if (!content.includes(dataJson.message)) {
+      throw new Error(`Page ${page} didn't contain message from data.json.`);
+    }
+  }
 }

--- a/modules/builders/BUILD.bazel
+++ b/modules/builders/BUILD.bazel
@@ -29,6 +29,7 @@ ts_library(
         "@npm//@angular-devkit/build-angular",
         "@npm//@angular-devkit/core",
         "@npm//@types/browser-sync",
+        "@npm//@types/express",
         "@npm//browser-sync",
         "@npm//guess-parser",
         "@npm//http-proxy-middleware",

--- a/modules/builders/package.json
+++ b/modules/builders/package.json
@@ -32,6 +32,7 @@
     "@angular-devkit/core": "DEVKIT_CORE_VERSION",
     "@nguniversal/common": "0.0.0-PLACEHOLDER",
     "browser-sync": "^2.26.7",
+    "express": "^4.17.1",
     "guess-parser": "^0.4.12",
     "http-proxy-middleware": "^2.0.0",
     "jest-worker": "26.6.2",

--- a/modules/builders/src/static-generator/worker.ts
+++ b/modules/builders/src/static-generator/worker.ts
@@ -22,12 +22,16 @@ export function setup(options: WorkerSetupArgs): void {
   sharedOptions = options;
 }
 
-export async function render(options: { outputPath: string; route: string }): Promise<void> {
-  const { outputPath, route } = options;
+export async function render(options: {
+  outputPath: string;
+  route: string;
+  port: number;
+}): Promise<void> {
+  const { outputPath, route, port } = options;
   const html = await engine.render({
     publicPath: outputPath,
     inlineCriticalCss: sharedOptions.inlineCriticalCss,
-    url: `http://localhost/${route}`,
+    url: `http://localhost:${port}/${route}`,
   });
 
   // This case happens when we are prerendering "/".


### PR DESCRIPTION
Using express to spawn a local static server for browser build artifacts which allows HTTP requests to a relative path like `/assets/data.json` while rendering.

Close #2132 

cc/ @alan-agius4 