### PR TITLE
build: update version to `12.2.0-next.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nguniversal",
   "main": "index.js",
-  "version": "12.1.0-next.0",
+  "version": "12.2.0-next.0",
   "private": true,
   "description": "Universal (isomorphic) JavaScript support for Angular",
   "homepage": "https://github.com/angular/universal",


### PR DESCRIPTION
Now that `12.1.0` has been released, the next prerelease is `12.2.0-next.0`.

I tried to do this via a direct push as expected in the [release doc](https://github.com/angular/universal/blob/4f9c6bafbfeeef17a3f66c5952135d9514c62dea/docs/process/release.md), but apparently `master` is a protected branch and refuses any update without a review. Might also want to update the doc?