### PR TITLE
fix(@nguniversal/common): inlineCriticalCssProcessor `outputPath` fallback to `''`

### DIFF
--- a/modules/common/engine/src/engine.ts
+++ b/modules/common/engine/src/engine.ts
@@ -120,7 +120,7 @@ export class CommonEngine {
 
     const { content, errors, warnings } = await this.inlineCriticalCssProcessor.process(html, {
       outputPath:
-        opts.publicPath ?? (opts.documentFilePath ? dirname(opts.documentFilePath) : undefined),
+        opts.publicPath ?? (opts.documentFilePath ? dirname(opts.documentFilePath) : ''),
     });
 
     // tslint:disable-next-line: no-console


### PR DESCRIPTION
Currently the `outputPath`  is fallback to `undefined`, which leads to critters option `path` is undefined,

[critters/src/index.js#L111](https://github.com/GoogleChromeLabs/critters/blob/main/packages/critters/src/index.js#L111)

```js
export default class Critters {
  /** @private */
  constructor(options) {
    this.options = Object.assign(
      {
        logLevel: 'info',
        path: '',
        publicPath: '',
        reduceInlineStyles: true,
        pruneSource: false,
        additionalStylesheets: [],
      },
      options || {}
    );
```

finally cause error when calling `require('path').resolve()` with parameter `undefined`.

[critters/src/index.js#L230](https://github.com/GoogleChromeLabs/critters/blob/main/packages/critters/src/index.js#L230)

```js
  async getCssAsset(href) {
    const outputPath = this.options.path;
    const publicPath = this.options.publicPath;

    // CHECK - the output path
    // path on disk (with output.publicPath removed)
    let normalizedPath = href.replace(/^\//, '');
    const pathPrefix = (publicPath || '').replace(/(^\/|\/$)/g, '') + '/';
    if (normalizedPath.indexOf(pathPrefix) === 0) {
      normalizedPath = normalizedPath
        .substring(pathPrefix.length)
        .replace(/^\//, '');
    }
    const filename = path.resolve(outputPath, normalizedPath); // outputPath is `undefined`
```