### PR TITLE
Revert "fix: remove the toPromise()"

### DIFF
--- a/modules/common/src/transfer_http.ts
+++ b/modules/common/src/transfer_http.ts
@@ -6,18 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {
+  HTTP_INTERCEPTORS,
   HttpEvent,
   HttpHandler,
   HttpHeaders,
   HttpInterceptor,
   HttpParams,
   HttpRequest,
-  HttpResponse, HTTP_INTERCEPTORS
+  HttpResponse,
 } from '@angular/common/http';
 import { ApplicationRef, Injectable, NgModule } from '@angular/core';
 import {
-  BrowserTransferStateModule, makeStateKey, StateKey,
-  TransferState
+  BrowserTransferStateModule,
+  StateKey,
+  TransferState,
+  makeStateKey,
 } from '@angular/platform-browser';
 import { Observable, of as observableOf } from 'rxjs';
 import { filter, take, tap } from 'rxjs/operators';
@@ -68,12 +71,15 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
     // Stop using the cache if the application has stabilized, indicating initial rendering is
     // complete.
     // tslint:disable-next-line: no-floating-promises
-    appRef.isStable.pipe(
-      filter((isStable: boolean) => isStable),
-      take(1),
-    ).subscribe(() => {
-      this.isCacheActive = false;
-    });
+    appRef.isStable
+      .pipe(
+        filter((isStable: boolean) => isStable),
+        take(1),
+      )
+      .toPromise()
+      .then(() => {
+        this.isCacheActive = false;
+      });
   }
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
@@ -135,4 +141,4 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
     { provide: HTTP_INTERCEPTORS, useExisting: TransferHttpCacheInterceptor, multi: true },
   ],
 })
-export class TransferHttpCacheModule { }
+export class TransferHttpCacheModule {}


### PR DESCRIPTION
Reverts angular/universal#2250

Following a convo with @CaerusKaru 

Promise is  there because Promises are microtasks vs Observables which are macrotasks. And that isStable only fires when the macrotask queue is empty, which it would never be since that last observable wraps it
