### PR TITLE
fix(@nguniversal/builders): index.original.html should be used if exists

### DIFF
--- a/modules/builders/src/prerender/worker.ts
+++ b/modules/builders/src/prerender/worker.ts
@@ -50,7 +50,10 @@ export async function render(
 
   const { renderModule, AppServerModule } = await import(serverBundlePath);
 
-  const browserIndexInputPath = path.join(outputPath, workerArgs.indexFile);
+  const indexBaseName = fs.existsSync(path.join(outputPath, 'index.original.html'))
+    ? 'index.original.html'
+    : workerArgs.indexFile;
+  const browserIndexInputPath = path.join(outputPath, indexBaseName);
   let indexHtml = await fs.promises.readFile(browserIndexInputPath, 'utf8');
   indexHtml = indexHtml.replace(
     '</html>',


### PR DESCRIPTION
I have found (what i think it is) a small bug when prerendering multiples routes:

The **render** function on the worker will backup browserIndexOutputPath to _index.original.html_ when prerender.

But that **render** function will read (always) index.html (workerArgs.indexFile), whenever it is rendering a new route.

I have found a strange behaviour when prerendering a large number of routes (or using "numProcesses": 1), since render will be using the already pre-rendered html.

For example it will generate a duplicated (and diferent depending on the routes) app-state json script tag.

A quick workaround is prerendering the route "/",  the last of the routes, but I find checking on "index.original.html" a much better approach. 

