### PR TITLE
feat(@nguniversal/common): disable critical CSS inlining by default

### DIFF
--- a/modules/common/clover/server/src/server-engine.ts
+++ b/modules/common/clover/server/src/server-engine.ts
@@ -48,7 +48,7 @@ export class Engine {
       pathname,
       options.htmlFilename,
     );
-    const inlineCriticalCss = options.inlineCriticalCss !== false;
+    const inlineCriticalCss = options.inlineCriticalCss === true;
 
     const customResourceLoader = new CustomResourceLoader(
       origin,

--- a/modules/common/engine/src/engine.ts
+++ b/modules/common/engine/src/engine.ts
@@ -29,7 +29,7 @@ export interface RenderOptions {
   documentFilePath?: string;
   /**
    * Reduce render blocking requests by inlining critical CSS.
-   * Defaults to true.
+   * Defaults to false.
    */
   inlineCriticalCss?: boolean;
   /**
@@ -64,7 +64,7 @@ export class CommonEngine {
    * render options
    */
   async render(opts: RenderOptions): Promise<string> {
-    const { inlineCriticalCss = true } = opts;
+    const { inlineCriticalCss = false } = opts;
 
     if (opts.publicPath && opts.documentFilePath && opts.url !== undefined) {
       const url = new URL(opts.url);


### PR DESCRIPTION
With this change we disable critical css inline by default. The main motivations are the following issues https://github.com/angular/angular-cli/issues/20760 and https://github.com/angular/angular-cli/issues/20864.

BREAKING CHANGE:

Inlining of critical CSS is no longer enable by default. Users already on Angular version 12 and have not opted-out from using this feature are encouraged to opt-in using the `inlineCriticalCss` option.

The motivation behind this change is that the package used to parse the CSS has a number of defects which can lead to unactionable error messages when updating to Angular 13 from versions priors to 12. Such errors can be seen in the following issue https://github.com/angular/angular-cli/issues/20760.