### PR TITLE
test: re-enable builders tests

### DIFF
--- a/integration/common-engine/src/main.server.ts
+++ b/integration/common-engine/src/main.server.ts
@@ -7,4 +7,4 @@ if (environment.production) {
 }
 
 export { AppServerModule } from './app/app.server.module';
-export { renderModule, renderModuleFactory } from '@angular/platform-server';
+export { renderModule } from '@angular/platform-server';

--- a/integration/express-engine-ivy-hybrid/src/main.server.ts
+++ b/integration/express-engine-ivy-hybrid/src/main.server.ts
@@ -7,4 +7,4 @@ if (environment.production) {
 }
 
 export { AppServerModule } from './app/app.server.module';
-export { renderModule, renderModuleFactory } from '@angular/platform-server';
+export { renderModule } from '@angular/platform-server';

--- a/integration/express-engine-ivy/src/main.server.ts
+++ b/integration/express-engine-ivy/src/main.server.ts
@@ -7,4 +7,4 @@ if (environment.production) {
 }
 
 export { AppServerModule } from './app/app.server.module';
-export { renderModule, renderModuleFactory } from '@angular/platform-server';
+export { renderModule } from '@angular/platform-server';

--- a/integration/hapi-engine-ivy/src/main.server.ts
+++ b/integration/hapi-engine-ivy/src/main.server.ts
@@ -7,4 +7,4 @@ if (environment.production) {
 }
 
 export { AppServerModule } from './app/app.server.module';
-export { renderModule, renderModuleFactory } from '@angular/platform-server';
+export { renderModule } from '@angular/platform-server';

--- a/modules/aspnetcore-engine/package.json
+++ b/modules/aspnetcore-engine/package.json
@@ -26,8 +26,7 @@
   "peerDependencies": {
     "@angular/common": "NG_VERSION",
     "@angular/core": "NG_VERSION",
-    "@nguniversal/common": "0.0.0-PLACEHOLDER",
-    "rxjs": "RXJS_VERSION"
+    "@nguniversal/common": "0.0.0-PLACEHOLDER"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP",

--- a/modules/builders/BUILD.bazel
+++ b/modules/builders/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+load("//tools:defaults.bzl", "jasmine_node_test", "pkg_npm", "ts_library")
 
 filegroup(
     name = "builders_assets",
@@ -70,7 +70,6 @@ ts_library(
         "@npm//@angular/platform-browser",
         "@npm//@angular/platform-browser-dynamic",
         "@npm//@angular/router",
-        "@npm//@angular/service-worker",
         "@npm//@types/browser-sync",
         "@npm//browser-sync",
         "@npm//express",
@@ -80,17 +79,21 @@ ts_library(
     ],
 )
 
-# TODO investigate and enable after we land APF version 13
-# The main reason for this is due to https://github.com/angular/angular/blob/e1c2fbd2aff5c4dce29d1153cea4ce117b7d83f5/packages/bazel/src/ng_package/ng_package.bzl#L542-L549
-# jasmine_node_test(
-#     name = "unit_test",
-#     srcs = [":unit_test_lib"],
-#     data = glob([
-#         "testing/hello-world-app/**/*",
-#     ]),
-#     deps = [
-#         "//modules/express-engine",
-#         "//modules/common",
-#         ":npm_package",
-#     ]
-# )
+jasmine_node_test(
+    name = "unit_test",
+    srcs = [":unit_test_lib"],
+    data = glob([
+        "testing/hello-world-app/**/*",
+    ]),
+    deps = [
+        ":common_npm_package_workaround",
+        ":npm_package",
+    ],
+)
+
+# Workaround for https://github.com/angular/angular/blob/e1c2fbd2aff5c4dce29d1153cea4ce117b7d83f5/packages/bazel/src/ng_package/ng_package.bzl#L542-L549
+pkg_npm(
+    name = "common_npm_package_workaround",
+    package_name = "@nguniversal/common",
+    srcs = ["//modules/common:npm_package"],
+)

--- a/modules/builders/src/prerender/index.spec.ts
+++ b/modules/builders/src/prerender/index.spec.ts
@@ -162,7 +162,10 @@ describe('Prerender Builder', () => {
     await run.stop();
   });
 
-  it('should generate service-worker', async () => {
+  // TODO: currently the `@angular/service-worker/config` package is
+  // always resolved from the workspace root which under Bazel is not present.
+  // https://github.com/angular/angular-cli/blob/c44f1229739567d19e2a282fc38efb419381eba7/packages/angular_devkit/build_angular/src/utils/service-worker.ts#L76-L85
+  xit('should generate service-worker', async () => {
     const manifest = {
       index: '/index.html',
       assetGroups: [

--- a/modules/builders/src/prerender/index.spec.ts
+++ b/modules/builders/src/prerender/index.spec.ts
@@ -165,6 +165,7 @@ describe('Prerender Builder', () => {
   // TODO: currently the `@angular/service-worker/config` package is
   // always resolved from the workspace root which under Bazel is not present.
   // https://github.com/angular/angular-cli/blob/c44f1229739567d19e2a282fc38efb419381eba7/packages/angular_devkit/build_angular/src/utils/service-worker.ts#L76-L85
+  // https://github.com/angular/angular-cli/pull/21895
   xit('should generate service-worker', async () => {
     const manifest = {
       index: '/index.html',

--- a/modules/builders/src/prerender/utils.spec.ts
+++ b/modules/builders/src/prerender/utils.spec.ts
@@ -6,78 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { BuilderContext } from '@angular-devkit/architect';
 import { BrowserBuilderOptions } from '@angular-devkit/build-angular';
-import { logging } from '@angular-devkit/core';
-import * as fs from 'fs';
-import * as guessParser from 'guess-parser';
-
-import { PrerenderBuilderOptions } from './models';
-import { getIndexOutputFile, getRoutes, shardArray } from './utils';
+import { getIndexOutputFile, shardArray } from './utils';
 
 describe('Prerender Builder Utils', () => {
-  describe('#getRoutes', () => {
-    const ROUTES_FILE = './routes.txt';
-    const ROUTES_FILE_CONTENT = ['/route1', '/route1', '/route2', '/route3'].join('\n');
-    const ROUTES = ['/route3', '/route3', '/route4'];
-    const GUESSED_ROUTES: any = [
-      { path: '/route4' },
-      { path: '/route5' },
-      { path: '/**' },
-      { path: '/user/:id' },
-    ];
-
-    const TSCONFIG_PATH = 'tsconfig.app.json';
-    const CONTEXT = {
-      workspaceRoot: '/path/to/angular/json',
-      logger: new logging.NullLogger(),
-    } as unknown as BuilderContext;
-
-    let parseAngularRoutesSpy: jasmine.Spy;
-    let loggerErrorSpy: jasmine.Spy;
-
-    beforeEach(() => {
-      spyOn(fs, 'readFileSync').and.returnValue(ROUTES_FILE_CONTENT);
-      parseAngularRoutesSpy = spyOn(guessParser, 'parseAngularRoutes').and.returnValue(
-        GUESSED_ROUTES,
-      );
-      loggerErrorSpy = spyOn(CONTEXT.logger, 'error');
-    });
-
-    // eslint-disable-next-line max-len
-    it('Should return the union of the routes from routes, routesFile, and the extracted routes without any parameterized routes', async () => {
-      const options = {
-        routes: ROUTES,
-        routesFile: ROUTES_FILE,
-        guessRoutes: true,
-      } as PrerenderBuilderOptions;
-      const routes = await getRoutes(options, TSCONFIG_PATH, CONTEXT);
-      expect(routes).toEqual(
-        jasmine.arrayContaining(['/route1', '/route2', '/route3', '/route4', '/route5']),
-      );
-    });
-
-    it('Should return only the given routes', async () => {
-      const options = { routes: ROUTES } as PrerenderBuilderOptions;
-      const routes = await getRoutes(options, TSCONFIG_PATH, CONTEXT);
-      expect(routes).toEqual(jasmine.arrayContaining(['/route3', '/route4']));
-    });
-
-    it('Should return the routes from the routesFile', async () => {
-      const options = { routesFile: ROUTES_FILE } as PrerenderBuilderOptions;
-      const routes = await getRoutes(options, TSCONFIG_PATH, CONTEXT);
-      expect(routes).toEqual(jasmine.arrayContaining(['/route1', '/route2', '/route3']));
-    });
-
-    it('Should catch errors thrown by parseAngularRoutes', async () => {
-      const options = { routes: ROUTES, guessRoutes: true } as PrerenderBuilderOptions;
-      parseAngularRoutesSpy.and.throwError('Test Error');
-      const routes = await getRoutes(options, TSCONFIG_PATH, CONTEXT);
-      expect(routes).toEqual(jasmine.arrayContaining(['/route3', '/route4']));
-      expect(loggerErrorSpy).toHaveBeenCalled();
-    });
-  });
-
   describe('#shardArray', () => {
     const ARRAY = [0, 1, 2, 3, 4];
     it('Should shard an array into numshards shards', () => {

--- a/modules/builders/testing/hello-world-app/angular.json
+++ b/modules/builders/testing/hello-world-app/angular.json
@@ -2,6 +2,11 @@
   "$schema": "../../../../node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "newProjectRoot": "projects",
+  "cli": {
+    "cache": {
+      "enabled": false
+    }
+  },
   "projects": {
     "app": {
       "projectType": "application",

--- a/modules/builders/testing/hello-world-app/src/main.server.ts
+++ b/modules/builders/testing/hello-world-app/src/main.server.ts
@@ -7,4 +7,4 @@ if (environment.production) {
 }
 
 export { AppServerModule } from './app/app.server.module';
-export { renderModule, renderModuleFactory } from '@angular/platform-server';
+export { renderModule } from '@angular/platform-server';

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@types/jasmine": "^3.4.4",
     "@types/jsdom": "^16.2.10",
     "@types/node": "12.12.37",
-    "@types/shelljs": "^0.8.6",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
     "browser-sync": "^2.26.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,8 +251,7 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#d008ca5d1aeebd192c7dca25d6eb09b9e69140c6":
   version "0.0.0"
-  uid d008ca5d1aeebd192c7dca25d6eb09b9e69140c6
-  resolved "https://github.com/angular/dev-infra-private-builds.git#d008ca5d1aeebd192c7dca25d6eb09b9e69140c6"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#3b7b500552a84b0173476f606ac66a4f2ecfd25b"
   dependencies:
     "@actions/core" "^1.4.0"
     "@actions/github" "^5.0.0"
@@ -2272,14 +2271,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@*":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
-  integrity sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
 "@types/hapi__boom@7.4.1":
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/@types/hapi__boom/-/hapi__boom-7.4.1.tgz#06439d7637245dcbe6dd6548d2a91f2c1243d80b"
@@ -2407,7 +2398,7 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
-"@types/minimatch@*", "@types/minimatch@^3.0.3":
+"@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
@@ -2480,14 +2471,6 @@
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
   dependencies:
     "@types/mime" "^1"
-    "@types/node" "*"
-
-"@types/shelljs@^0.8.6":
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.9.tgz#45dd8501aa9882976ca3610517dac3831c2fbbf4"
-  integrity sha512-flVe1dvlrCyQJN/SGrnBxqHG+RzXrVKsmjD8WS/qYHpq5UPjfq7UWFBENP0ZuOl0g6OpAlL6iBoLSvKYUUmyQw==
-  dependencies:
-    "@types/glob" "*"
     "@types/node" "*"
 
 "@types/tough-cookie@*":


### PR DESCRIPTION
With this change we re-enable the builders unit tests. We had to delete some utils specs since they were not written in a way to works with TypeScripts' esModuleInterop which causes exports to be read only.