### PR TITLE
Revert "feat(@nguniversal/common): disable critical CSS inlining by default"

### DIFF
--- a/modules/common/clover/server/src/server-engine.ts
+++ b/modules/common/clover/server/src/server-engine.ts
@@ -48,7 +48,7 @@ export class Engine {
       pathname,
       options.htmlFilename,
     );
-    const inlineCriticalCss = options.inlineCriticalCss === true;
+    const inlineCriticalCss = options.inlineCriticalCss !== false;
 
     const customResourceLoader = new CustomResourceLoader(
       origin,

--- a/modules/common/engine/src/engine.ts
+++ b/modules/common/engine/src/engine.ts
@@ -22,7 +22,7 @@ export interface RenderOptions {
   documentFilePath?: string;
   /**
    * Reduce render blocking requests by inlining critical CSS.
-   * Defaults to false.
+   * Defaults to true.
    */
   inlineCriticalCss?: boolean;
   /**
@@ -53,7 +53,7 @@ export class CommonEngine {
    * render options
    */
   async render(opts: RenderOptions): Promise<string> {
-    const { inlineCriticalCss = false } = opts;
+    const { inlineCriticalCss = true } = opts;
 
     if (opts.publicPath && opts.documentFilePath && opts.url !== undefined) {
       const url = new URL(opts.url);


### PR DESCRIPTION
Reverts angular/universal#2349

Related to https://github.com/angular/angular-cli/pull/21899