### PR TITLE
test: turn off `@typescript-eslint/no-unsafe-argument`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -93,6 +93,7 @@
     "@typescript-eslint/no-implied-eval": "off",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-unnecessary-type-assertion": "off",
+    "@typescript-eslint/no-unsafe-argument": "off",
     "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-unsafe-call": "off",
     "@typescript-eslint/no-unsafe-member-access": "off",


### PR DESCRIPTION
`no-unsafe-argument` was turned on by default in version 5 but our code is non-compliant and a number of lint errors.