### PR TITLE
fix(@nguniversal/express-engine): update schematic to be `noPropertyAccessFromIndexSignature` compliant

### DIFF
--- a/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -38,7 +38,7 @@ export function app(): express.Express {
 }
 
 function run(): void {
-  const port = process.env.PORT || <%= serverPort %>;
+  const port = process.env['PORT'] || <%= serverPort %>;
 
   // Start up the Node server
   const server = app();


### PR DESCRIPTION

When usign the CLI in strict mode `noPropertyAccessFromIndexSignature` typescript option will be enabled which forces index signatures to be accessed with square brackets.