### PR TITLE
fix(@nguniversal/express-engine): initialNavigation should be 'enabledBlocking'

### DIFF
--- a/modules/express-engine/schematics/utils/utils.ts
+++ b/modules/express-engine/schematics/utils/utils.ts
@@ -134,7 +134,7 @@ export function addInitialNavigation(node: ts.CallExpression): ts.CallExpression
     return node;
   }
 
-  const enabledLiteral = ts.createStringLiteral('enabled');
+  const enabledLiteral = ts.createStringLiteral('enabledBlocking');
   // TypeScript will emit the Node with double quotes.
   // In schematics we usually write code with a single quotes
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
According to the [document](https://angular.io/api/router/InitialNavigation#description), `initialNavigation: 'enabled'` have been deprecated.

It should be `initialNavigation: 'enabledBlocking'` now.