### PR TITLE
Ensure CommonJS migrations can be accessed

### DIFF
--- a/modules/common/schematics/BUILD.bazel
+++ b/modules/common/schematics/BUILD.bazel
@@ -32,7 +32,22 @@ ts_library(
 # This package is intended to be combined into the main @nguniversal/express-engine package as a dep.
 pkg_npm(
     name = "npm_package",
+    # We never set a `package_name` for NPM packages, neither do we enable validation.
+    # This is necessary because the source targets of the NPM packages all have
+    # package names set and setting a similar `package_name` on the NPM package would
+    # result in duplicate linker mappings that will conflict. e.g. consider the following
+    # scenario: We have a `ts_library` for `@angular/core`. We will configure a package
+    # name for the target so that it can be resolved in NodeJS executions from `node_modules`.
+    # If we'd also set a `package_name` for the associated `pkg_npm` target, there would be
+    # two mappings for `@angular/core` and the linker will complain. For a better development
+    # experience, we want the mapping to resolve to the direct outputs of the `ts_library`
+    # instead of requiring tests and other targets to assemble the NPM package first.
+    # TODO(alan-agius4): consider removing this if `rules_nodejs` allows for duplicate
+    # linker mappings where transitive-determined mappings are skipped on conflicts.
+    # https://github.com/bazelbuild/rules_nodejs/issues/2810.
+    package_name = None,
     srcs = [":schematics_assets"],
+    validate = False,
     deps = [":schematics"],
 )
 

--- a/modules/common/schematics/ng-add/files/src/server.ts.template
+++ b/modules/common/schematics/ng-add/files/src/server.ts.template
@@ -1,5 +1,5 @@
 import { Engine } from '@nguniversal/common/clover/server';
-import express from 'express';
+import * as express from 'express';
 import { join } from 'path';
 import { format } from 'url';
 

--- a/modules/common/schematics/package.json
+++ b/modules/common/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/modules/express-engine/schematics/BUILD.bazel
+++ b/modules/express-engine/schematics/BUILD.bazel
@@ -36,7 +36,22 @@ ts_library(
 # This package is intended to be combined into the main @nguniversal/express-engine package as a dep.
 pkg_npm(
     name = "npm_package",
+    # We never set a `package_name` for NPM packages, neither do we enable validation.
+    # This is necessary because the source targets of the NPM packages all have
+    # package names set and setting a similar `package_name` on the NPM package would
+    # result in duplicate linker mappings that will conflict. e.g. consider the following
+    # scenario: We have a `ts_library` for `@angular/core`. We will configure a package
+    # name for the target so that it can be resolved in NodeJS executions from `node_modules`.
+    # If we'd also set a `package_name` for the associated `pkg_npm` target, there would be
+    # two mappings for `@angular/core` and the linker will complain. For a better development
+    # experience, we want the mapping to resolve to the direct outputs of the `ts_library`
+    # instead of requiring tests and other targets to assemble the NPM package first.
+    # TODO(alan-agius4): consider removing this if `rules_nodejs` allows for duplicate
+    # linker mappings where transitive-determined mappings are skipped on conflicts.
+    # https://github.com/bazelbuild/rules_nodejs/issues/2810.
+    package_name = None,
     srcs = [":schematics_assets"],
+    validate = False,
     deps = [":schematics"],
 )
 

--- a/modules/express-engine/schematics/package.json
+++ b/modules/express-engine/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
Migrations are currently published as CommonJS and also not bundled. Schematics, of which migrations are a type, are currently required to be CommonJS modules due to the Schematics Runtime not yet supporting ESM-based schematics.

closes #2491