### PR TITLE
ci: fix permissions and tags

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -1,5 +1,9 @@
 name: DevInfra
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
@@ -8,7 +12,7 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: angular/dev-infra/github-actions/commit-message-based-labels@0eb963e22a7464c8794b21e73d829ecdd05bd086
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
+      - uses: angular/dev-infra/github-actions/commit-message-based-labels@104c49ad795097101ab3aa268a8e9af2cdf04a8d
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -1,14 +1,18 @@
-name: Lock closed inactive issues
+name: Lock Inactive Issues
+
+# Declare default permissions as read only.
+permissions:
+  contents: read
 
 on:
   schedule:
-    # Run at 8:00 every day
+    # Run at 08:00 every day
     - cron: '0 8 * * *'
 
 jobs:
   lock_closed:
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@0eb963e22a7464c8794b21e73d829ecdd05bd086
+      - uses: angular/dev-infra/github-actions/lock-closed@104c49ad795097101ab3aa268a8e9af2cdf04a8d
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,13 +2,14 @@ name: OpenSSF Scorecard
 on:
   branch_protection_rule:
   schedule:
-    - cron: '0 6 * * 0'
+    - cron: '0 2 * * 0'
   push:
     branches: [master]
   workflow_dispatch:
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:
@@ -22,12 +23,12 @@ jobs:
 
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
         with:
           persist-credentials: false
 
       - name: 'Run analysis'
-        uses: ossf/scorecard-action@869bc607582d2449c2529ebc09c7f49d30f0efde
+        uses: ossf/scorecard-action@c1aec4ac820532bab364f02a81873c555a0ba3a1 # tag=v1.0.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -36,7 +37,7 @@ jobs:
 
       # Upload the results as artifacts.
       - name: 'Upload artifact'
-        uses: actions/upload-artifact@2244c8200304ec9588bf9399eac622d9fadc28c4
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3.0.0
         with:
           name: SARIF file
           path: results.sarif
@@ -44,6 +45,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: 'Upload to code-scanning'
-        uses: github/codeql-action/upload-sarif@2c6b76bc5a6dafa5a35d5865bb3aa1c1f21e7a44
+        uses: github/codeql-action/upload-sarif@75f07e7ab2ee63cba88752d8c696324e4df67466 # tag=v1.1.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The currently recommended best practice for Github action workflows is to set top-level permissions to read only. And if the job uses the automatic `GITHUB_TOKEN`, fine-grained permissions for each job based on the job's requirements should also be added.
All existing workflows in the repository now have top-level read only permission blocks.

Only the `scorecard` workflow currently requires additional job level permissions and the minimum set of permissions were already present for the job.