### PR TITLE
feat(express-engine): schematics compatible with Node on Apache Passenger

### DIFF
--- a/integration/common-engine/server.ts
+++ b/integration/common-engine/server.ts
@@ -42,11 +42,24 @@ export function app(): express.Express {
   return server;
 }
 
-function run() {
-  const port = process.env.PORT || 4200;
+// on Passenger, the moduleFilename will contain a/path/to/lsnode.js
+function isRunningOnApachePassenger(): boolean {
+  return moduleFilename.includes('lsnode.js');
+}
 
+function run(): void {
   // Start up the Node server
   const server = app();
+
+  if (isRunningOnApachePassenger()) {
+    server.listen(() => {
+      console.log('Node Express listening to Passenger Apache');
+    });
+    return;
+  }
+
+  const port = process.env['PORT'] || 4000;
+
   server.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });
@@ -58,7 +71,8 @@ function run() {
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
 const moduleFilename = (mainModule && mainModule.filename) || '';
-if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
+if (moduleFilename === __filename || moduleFilename.includes('iisnode') ||
+isRunningOnApachePassenger()) {
   run();
 }
 

--- a/integration/express-engine-ivy-hybrid/server.ts
+++ b/integration/express-engine-ivy-hybrid/server.ts
@@ -45,11 +45,24 @@ export function app(): express.Express {
   return server;
 }
 
-function run() {
-  const port = process.env.PORT || 4000;
+// on Passenger, the moduleFilename will contain a/path/to/lsnode.js
+function isRunningOnApachePassenger(): boolean {
+  return moduleFilename.includes('lsnode.js');
+}
 
+function run(): void {
   // Start up the Node server
   const server = app();
+
+  if (isRunningOnApachePassenger()) {
+    server.listen(() => {
+      console.log('Node Express listening to Passenger Apache');
+    });
+    return;
+  }
+
+  const port = process.env['PORT'] || 4000;
+
   server.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });
@@ -61,7 +74,8 @@ function run() {
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
 const moduleFilename = (mainModule && mainModule.filename) || '';
-if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
+if (moduleFilename === __filename || moduleFilename.includes('iisnode') ||
+isRunningOnApachePassenger()) {
   run();
 }
 

--- a/integration/express-engine-ivy/server.ts
+++ b/integration/express-engine-ivy/server.ts
@@ -46,11 +46,24 @@ export function app(): express.Express {
   return server;
 }
 
-function run() {
-  const port = process.env.PORT || 4000;
+// on Passenger, the moduleFilename will contain a/path/to/lsnode.js
+function isRunningOnApachePassenger(): boolean {
+  return moduleFilename.includes('lsnode.js');
+}
 
+function run(): void {
   // Start up the Node server
   const server = app();
+
+  if (isRunningOnApachePassenger()) {
+    server.listen(() => {
+      console.log('Node Express listening to Passenger Apache');
+    });
+    return;
+  }
+
+  const port = process.env['PORT'] || 4000;
+
   server.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });
@@ -62,7 +75,8 @@ function run() {
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
 const moduleFilename = (mainModule && mainModule.filename) || '';
-if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
+if (moduleFilename === __filename || moduleFilename.includes('iisnode') ||
+isRunningOnApachePassenger()) {
   run();
 }
 

--- a/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -37,11 +37,24 @@ export function app(): express.Express {
   return server;
 }
 
-function run(): void {
-  const port = process.env['PORT'] || <%= serverPort %>;
+// on Passenger, the moduleFilename will contain a/path/to/lsnode.js
+function isRunningOnApachePassenger(): boolean {
+  return moduleFilename.includes('lsnode.js');
+}
 
+function run(): void {
   // Start up the Node server
   const server = app();
+
+  if (isRunningOnApachePassenger()) {
+    server.listen(() => {
+      console.log('Node Express listening to Passenger Apache');
+    });
+    return;
+  }
+
+  const port = process.env['PORT'] || 4000;
+
   server.listen(port, () => {
     console.log(`Node Express server listening on http://localhost:${port}`);
   });
@@ -53,7 +66,8 @@ function run(): void {
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
 const moduleFilename = mainModule && mainModule.filename || '';
-if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
+if (moduleFilename === __filename || moduleFilename.includes('iisnode')  ||
+isRunningOnApachePassenger()) {
   run();
 }
 


### PR DESCRIPTION
When deploying Universal to a Shared Hosting with Apache Passenger the server never starts because the `if` block is always false.

This PR adds an extra `of` checking if we are on a Passenger Env by checking if `moduleFilename` includes the path to [lsnode](https://github.com/rperper/lsnode).

Also starts the server without a port because no port is needed on Apache Passenger.

PS: I wanted to create a test for this but I could not figure out where...