### PR TITLE
refactor: update `master` branch to `13.2.0-next.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nguniversal",
   "main": "index.js",
-  "version": "13.1.0-next.1",
+  "version": "13.2.0-next.0",
   "private": true,
   "description": "Universal (isomorphic) JavaScript support for Angular",
   "homepage": "https://github.com/angular/universal",


### PR DESCRIPTION
This allows the `ng-dev` tool to accept the `13.1.x` branch as a minor release which doesn't conflict with `master`.

Trying to release currently fails with:

```
$ yarn -s ng-dev release publish
# ...
Error: Discovered unexpected version-branch "13.1.x" for a release-train that is already active in the "master" branch. Please either delete the branch if created by accident, or update the version in the next branch (master).
    at findActiveReleaseTrainsFromVersionBranches (/home/douglasparker/Source/universal/ng-dev/release/versioning/active-release-trains.ts:137:13)
    at fetchActiveReleaseTrains (/home/douglasparker/Source/universal/ng-dev/release/versioning/active-release-trains.ts:80:44)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ReleaseTool.run (/home/douglasparker/Source/universal/ng-dev/release/publish/index.ts:74:27)
    at async Object.handler (/home/douglasparker/Source/universal/ng-dev/release/publish/cli.ts:36:18)
```

This updates `master` to use `13.2.0-next.0` as the next prerelease. We likely won't publish that and will go directly to v14, but being in a minor will allow the tool to update to `14.0.0-next.0`, whereas if I updated manually to `14.0.0-next.0` now, then the tool would want the next release to be `14.0.0-next.1`.