### PR TITLE
build: changes for primary branch rename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
   setup:
     executor: action-executor
     steps:
-      # After checkout, rebase on top of master. By default, PRs are not rebased on top of master,
+      # After checkout, rebase on top of main. By default, PRs are not rebased on top of main,
       # which we want. See https://discuss.circleci.com/t/1662
       - checkout:
           post: git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
@@ -147,7 +147,7 @@ workflows:
 general:
   branches:
     only:
-      - master
+      - main
       # 5.2.x, 6.0.x, etc
       - /\d+\.\d+\.x/
       # 5.x, 6.x, etc

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 2 * * 0'
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 # Declare default permissions as read only.

--- a/.ng-dev/github.ts
+++ b/.ng-dev/github.ts
@@ -7,5 +7,5 @@ import { GithubConfig } from '@angular/dev-infra-private/ng-dev/utils/config';
 export const github: GithubConfig = {
   owner: 'angular',
   name: 'universal',
-  mainBranchName: 'master',
+  mainBranchName: 'main',
 };

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "baseBranches": ["master"],
+  "baseBranches": ["main"],
   "ignoreDeps": ["@types/node"],
   "includePaths": [
     "WORKSPACE",


### PR DESCRIPTION
Changes from the `DIRECT` phase of the renaming master
to main planning doc.

Note: Skipping LTS backports here since we don't make any guarantees for the universal repo
and its likely not worth (we would need more ng-dev backports there as well)