### PR TITLE
fix(@nguniversal/common): add a marker for SSR pages

### DIFF
--- a/modules/builders/src/prerender/worker.ts
+++ b/modules/builders/src/prerender/worker.ts
@@ -50,7 +50,7 @@ export async function render({
   let indexHtml = await fs.promises.readFile(browserIndexInputPath, 'utf8');
   indexHtml = indexHtml.replace(
     '</html>',
-    '<!-- This page was prerendered with Angular Universal -->\n</html>',
+    '<!-- This page was prerendered with Angular Universal (SSG) -->\n</html>',
   );
   if (inlineCriticalCss) {
     // Workaround for https://github.com/GoogleChromeLabs/critters/issues/64

--- a/modules/common/engine/src/engine.ts
+++ b/modules/common/engine/src/engine.ts
@@ -101,7 +101,11 @@ export class CommonEngine {
     }
 
     const moduleOrFactory = this.module || opts.bootstrap;
-    const html = await renderModule(moduleOrFactory, { extraProviders });
+    const html = (await renderModule(moduleOrFactory, { extraProviders })).replace(
+      '</html>',
+      '<!-- This page was rendered with Angular Universal (SSR) -->\n</html>',
+    );
+
     if (!inlineCriticalCss) {
       return html;
     }


### PR DESCRIPTION
This provides an easy way to distinguish between SSR, SSG, and client-side apps (CSR).

Closes #2612

//cc @mgechev