### PR TITLE
fix(@nguniversal/common): correctly handle headers for jsdom in Clover

### DIFF
--- a/modules/common/clover/server/src/custom-resource-loader.ts
+++ b/modules/common/clover/server/src/custom-resource-loader.ts
@@ -12,11 +12,14 @@ import { normalize } from 'path';
 
 export class CustomResourceLoader extends ResourceLoader {
   constructor(
-    private readonly baseUrl: string,
+    readonly headers: Record<string, string | undefined | string[]> | undefined,
     private readonly publicPath: string,
+    private readonly baseUrl: string,
     private readonly fileCache: Map<string, Buffer>,
   ) {
-    super();
+    super({
+      userAgent: headers?.['user-agent'] as string | undefined,
+    });
   }
 
   fetch(url: string, _options: FetchOptions): AbortablePromise<Buffer> | null {

--- a/modules/common/clover/server/src/server-engine.ts
+++ b/modules/common/clover/server/src/server-engine.ts
@@ -51,8 +51,9 @@ export class Engine {
     const inlineCriticalCss = options.inlineCriticalCss !== false;
 
     const customResourceLoader = new CustomResourceLoader(
-      origin,
+      options.headers,
       options.publicPath,
+      origin,
       this.resourceLoaderCache,
     );
 
@@ -76,7 +77,6 @@ export class Engine {
         resources: customResourceLoader,
         url: options.url,
         referrer: options.headers?.referrer as string | undefined,
-        userAgent: options.headers?.['user-agent'] as string | undefined,
         beforeParse: (window) => {
           augmentWindowWithStubs(window);
           window.ngRenderMode = true;


### PR DESCRIPTION
---
name: ⚙ fix
about: [correctly handle headers for jsdom in Clover
---


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/universal/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type: Bugfix

## What is the current behavior?

the server agent is not working in angular. it just default fallback of jsdom

![image](https://user-images.githubusercontent.com/16970990/171993343-1fd85ab0-be3d-442d-9ce0-c7f507fcb743.png)

the user agent is not corect ly handle by Clover, we should make it correct.

Right now the userAgent is passing in jsdom options which is not correct. We should move it to customResourceLoader  

## What is the new behavior?

the user agent handle correctly as jsdom suggestion. Move userAgent to ResouceLoader as document


![image](https://user-images.githubusercontent.com/16970990/171993389-46ffc275-ddfa-480d-83af-cbe0ef8a4c54.png)

![image](https://user-images.githubusercontent.com/16970990/171993856-f78aea7a-9711-4998-b7c6-e480938ce4cf.png)

after modification, the userAgent work correctly

![image](https://user-images.githubusercontent.com/16970990/171994205-7df3dda6-a450-4717-b639-def9423f360c.png)


we just update it as the document

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm runing Clover on production app on https://awread.vn. I tested this change on my production and it work very good. I love this engine so much. Thanks for your effort
