### PR TITLE
build: update contributing guide to reflect branch name of `code-of-conduct` repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 - For corporations we'll need you to
   [print, sign and one of scan+email, fax or mail the form][corporate-cla].
 
-[coc]: https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md
+[coc]: https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
 [corporate-cla]: http://code.google.com/legal/corporate-cla-v1.0.html
 [dev-doc]: https://github.com/angular/angular/blob/main/DEVELOPER.md


### PR DESCRIPTION
Updates the contributing guide to reflect the branch name of `code-of-conduct` repository