### PR TITLE
fix(@nguniversal/common): handle `ngDevMode` correctly

### DIFF
--- a/modules/common/clover/src/styles_host.ts
+++ b/modules/common/clover/src/styles_host.ts
@@ -34,7 +34,7 @@ export class SSRStylesHost extends SharedStylesHost implements OnDestroy {
   private _addStyle(style: string): void {
     const element = this._styleNodesInDOM?.get(style);
     if (element) {
-      if (typeof ngDevMode !== undefined && ngDevMode) {
+      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
         element.setAttribute('_ng-style-re-used', '');
       }
 


### PR DESCRIPTION
I've updated the check for `ngDevMode` since `!== undefined` will always return true even tho it's not explicitly provided by Terser.