### PR TITLE
build: enable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,16 @@
 {
-  "pinVersions": false,
-  "semanticCommits": true,
-  "semanticPrefix": "build",
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "rangeStrategy": "replace",
+  "semanticCommits": "enabled",
+  "semanticCommitType": "build",
+  "semanticCommitScope": "",
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
   "labels": ["target: minor", "action: merge"],
   "timezone": "America/Tijuana",
-  "lockFileMaintenance": {
-    "enabled": true
-  },
+  "lockFileMaintenance": { "enabled": true },
+  "dependencyDashboard": true,
+  "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
   "ignoreDeps": ["@types/node"],
   "includePaths": [


### PR DESCRIPTION
Enable the Renovate dashboard to see what we are missing/what
is going on after switching to the self-hosted runner. Renovate
might avoid some PRs due to previously-closed old PRs with
the official Mend renovate app operating on upstream branches.

Also provide the Renovate schema.