### PR TITLE
docs: release notes for the v14.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+<a name="14.0.3"></a>
+
+# 14.0.3 (2022-07-06)
+
+### @nguniversal/common
+
+| Commit                                                                                           | Type | Description                  |
+| ------------------------------------------------------------------------------------------------ | ---- | ---------------------------- |
+| [b68cc08a](https://github.com/angular/universal/commit/b68cc08a065d4a657d8d4f374aaa605e9ff9098a) | fix  | handle `ngDevMode` correctly |
+
+## Special Thanks
+
+Alan Agius, Paul Gschwendtner and arturovt
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="14.1.0-next.1"></a>
 
 # 14.1.0-next.1 (2022-06-23)


### PR DESCRIPTION
Cherry-picks the changelog from the "14.0.x" branch to the next branch (main).