### PR TITLE
fix(@nguniversal/express-engine): remove default value of `appDir` option

### DIFF
--- a/modules/express-engine/schematics/install/schema.json
+++ b/modules/express-engine/schematics/install/schema.json
@@ -37,7 +37,7 @@
       "type": "string",
       "format": "path",
       "description": "The name of the application directory.",
-      "default": "app"
+      "x-deprecated": "This option has no effect."
     },
     "rootModuleFileName": {
       "type": "string",

--- a/modules/express-engine/schematics/install/schema.ts
+++ b/modules/express-engine/schematics/install/schema.ts
@@ -29,6 +29,7 @@ export interface Schema {
   serverPort?: number;
   /**
    * The name of the application directory.
+   * @deprecated This option has no longer any effect
    */
   appDir?: string;
   /**


### PR DESCRIPTION

This option is no longer used by the universal schematic.

Fixes #2779