### PR TITLE
Update next branch to reflect new release-train "v14.3.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+<a name="14.2.0-rc.0"></a>
+
+# 14.2.0-rc.0 (2022-09-07)
+
+### @nguniversal/common
+
+| Commit                                                                                           | Type | Description                                  |
+| ------------------------------------------------------------------------------------------------ | ---- | -------------------------------------------- |
+| [6dcce858](https://github.com/angular/universal/commit/6dcce858ee4dae07268f26835f27136a354d227c) | fix  | handle cookies with localhost domain as path |
+
+### @nguniversal/express-engine
+
+| Commit                                                                                           | Type | Description                             |
+| ------------------------------------------------------------------------------------------------ | ---- | --------------------------------------- |
+| [d9a13469](https://github.com/angular/universal/commit/d9a13469a039bfca94939ecac6201973990b7b96) | fix  | remove default value of `appDir` option |
+
+## Special Thanks
+
+Alan Agius and angular-robot[bot]
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="14.2.0-next.0"></a>
 
 # 14.2.0-next.0 (2022-08-17)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nguniversal",
   "main": "index.js",
-  "version": "14.2.0-next.0",
+  "version": "14.3.0-next.0",
   "private": true,
   "description": "Universal (isomorphic) JavaScript support for Angular",
   "homepage": "https://github.com/angular/universal",


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v14.2.0-rc.0 into the main branch so that the changelog is up to date.