### PR TITLE
feat(@nguniversal/builders): add sourcemap mapping support for dev-server

### DIFF
--- a/modules/builders/src/ssr-dev-server/index.ts
+++ b/modules/builders/src/ssr-dev-server/index.ts
@@ -180,7 +180,7 @@ function startNodeServer(
   const path = join(outputPath, 'main.js');
   const env = { ...process.env, PORT: '' + port };
 
-  const args = [`"${path}"`];
+  const args = ['--enable-source-maps', `"${path}"`];
   if (inspectMode) {
     args.unshift('--inspect-brk');
   }
@@ -190,7 +190,8 @@ function startNodeServer(
     switchMap(() => spawnAsObservable('node', args, { env, shell: true })),
     tap(({ stderr, stdout }) => {
       if (stderr) {
-        logger.error(stderr);
+        // Strip the webpack scheme (webpack://) from error log.
+        logger.error(stderr.replace(/webpack:\/\//g, '.'));
       }
 
       if (stdout && !IGNORED_STDOUT_MESSAGES.some((x) => stdout.includes(x))) {


### PR DESCRIPTION
Note: this requires Node.js 18.10 or later due to https://github.com/nodejs/node/issues/44654

Closes #2813