### PR TITLE
fix(@nguniversal/builders): import `zone.js` in worker during prerendering

### DIFF
--- a/modules/builders/src/prerender/index.ts
+++ b/modules/builders/src/prerender/index.ts
@@ -100,11 +100,13 @@ async function _renderUniversal(
     browserOptions.optimization,
   );
 
+  const zonePackage = require.resolve('zone.js', { paths: [context.workspaceRoot] });
+
   const { baseOutputPath = '' } = serverResult;
   const worker = new Piscina({
     filename: path.join(__dirname, 'worker.js'),
-    name: 'render',
     maxThreads: numProcesses,
+    workerData: { zonePackage },
   });
 
   try {
@@ -131,7 +133,7 @@ async function _renderUniversal(
               serverBundlePath,
             };
 
-            return worker.run(options, { name: 'render' });
+            return worker.run(options);
           }),
         )) as RenderResult[];
         let numErrors = 0;

--- a/modules/builders/testing/hello-world-app/src/main.server.ts
+++ b/modules/builders/testing/hello-world-app/src/main.server.ts
@@ -1,3 +1,5 @@
+import 'zone.js';
+
 import { enableProdMode } from '@angular/core';
 import { environment } from './environments/environment';
 


### PR DESCRIPTION

In some cases, zone.js might not be part of the bundle, which cause zone async task not be patched and awaited correctly prior of rendering.