### PR TITLE
fix(@nguniversal/common): mark `bootstrap` in `RenderOptions` as non required

### DIFF
--- a/modules/common/engine/src/engine.ts
+++ b/modules/common/engine/src/engine.ts
@@ -15,7 +15,7 @@ import { URL } from 'url';
 
 /** These are the allowed options for the render */
 export interface RenderOptions {
-  bootstrap: Type<{}>;
+  bootstrap?: Type<{}>;
   providers?: StaticProvider[];
   url?: string;
   document?: string;
@@ -105,6 +105,11 @@ export class CommonEngine {
     }
 
     const moduleOrFactory = this.module || opts.bootstrap;
+
+    if (!moduleOrFactory) {
+      throw new Error('A module or bootstrap option must be provided.');
+    }
+
     const html = await renderModule(moduleOrFactory, { extraProviders });
     if (!inlineCriticalCss) {
       return html;

--- a/modules/express-engine/src/main.ts
+++ b/modules/express-engine/src/main.ts
@@ -14,10 +14,10 @@ import type { Request, Response } from 'express';
 /**
  * These are the allowed options for the engine
  */
-export type NgSetupOptions = Pick<
-  CommonRenderOptions,
-  'bootstrap' | 'providers' | 'publicPath' | 'inlineCriticalCss'
->;
+export interface NgSetupOptions
+  extends Pick<CommonRenderOptions, 'providers' | 'publicPath' | 'inlineCriticalCss'> {
+  bootstrap: NonNullable<CommonRenderOptions['bootstrap']>;
+}
 
 /**
  * These are the allowed options for the render


### PR DESCRIPTION

This option is not required in the common engine.

Closes: #2893