### PR TITLE
docs: release notes for the v15.0.0-rc.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+<a name="15.0.0-rc.0"></a>
+
+# 15.0.0-rc.0 (2022-11-09)
+
+### @nguniversal/common
+
+| Commit                                                                                           | Type | Description                                         |
+| ------------------------------------------------------------------------------------------------ | ---- | --------------------------------------------------- |
+| [fb904948](https://github.com/angular/universal/commit/fb904948e996e9d7ea96915d6480248c999afd94) | fix  | mark `bootstrap` in `RenderOptions` as non required |
+
+## Special Thanks
+
+Alan Agius
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="14.2.2"></a>
 
 # 14.2.2 (2022-11-09)


### PR DESCRIPTION
Cherry-picks the changelog from the "15.0.x" branch to the next branch (main).