### PR TITLE
fix(@nguniversal/express-engine): fix formatting in generated `server.ts`

### DIFF
--- a/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -1,12 +1,12 @@
 import 'zone.js/node';
 
-import {APP_BASE_HREF} from '@angular/common';
-import {ngExpressEngine} from '@nguniversal/express-engine';
+import { APP_BASE_HREF } from '@angular/common';
+import { ngExpressEngine } from '@nguniversal/express-engine';
 import * as express from 'express';
-import {existsSync} from 'fs';
-import {join} from 'path';
+import { existsSync } from 'fs';
+import { join } from 'path';
 
-import {AppServerModule} from './src/<%= stripTsExtension(main) %>';
+import { AppServerModule } from './src/<%= stripTsExtension(main) %>';
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {


### PR DESCRIPTION
Add spacing to match other file generated by the Angular CLI