### PR TITLE
build: fix scorecard action signing

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,18 +7,20 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  actions: read
-  contents: read
-  # Needed to upload the results to code-scanning dashboard.
-  security-events: write
-  # Needed for signing and publishing of results for the badge.
-  id-token: write
+# Declare default permissions as read only.
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed for signing and publishing of results for the badge.
+      id-token: write
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # tag=v3.2.0


### PR DESCRIPTION
First of all, scorecard does not print a useful error at all. Looking through issues and their verify workflow logic, it seems like the permissions for the scorecard action workflow *need* to be set on the actual job itself, while the workflow-level permissions *cannot* contain any `write` permissions.

We already got further with the errors by enabling id-token write properly, but now the signing fails with an unknown error that we attempt to fix using this commit.