### PR TITLE
fix(@nguniversal/builders): disable bundle budgets when using the dev-server

### DIFF
--- a/modules/builders/src/ssr-dev-server/index.ts
+++ b/modules/builders/src/ssr-dev-server/index.ts
@@ -59,6 +59,8 @@ export function execute(
     serviceWorker: false,
     watch: true,
     progress: options.progress,
+    // Disable bundle budgets are these are not meant to be used with a dev-server as this will add extra JavaScript for live-reloading.
+    budgets: [],
   });
 
   const serverTargetRun = context.scheduleTarget(serverTarget, {


### PR DESCRIPTION


With this change we disable the bundle budgets when using the dev-server as extra JavaScript for live-reloading will be added which could cause budgets to fail.

Closes: #2959