### PR TITLE
build: remove `defaults.bzl` version in favor of version in `package.json`

### DIFF
--- a/modules/builders/package.json
+++ b/modules/builders/package.json
@@ -25,11 +25,11 @@
   "typings": "src/index.d.ts",
   "builders": "builders.json",
   "peerDependencies": {
-    "@angular-devkit/build-angular": "DEVKIT_BUILD_ANGULAR_VERSION"
+    "@angular-devkit/build-angular": "^15.0.0"
   },
   "dependencies": {
-    "@angular-devkit/architect": "DEVKIT_ARCHITECT_VERSION",
-    "@angular-devkit/core": "DEVKIT_CORE_VERSION",
+    "@angular-devkit/architect": "~0.1500.0",
+    "@angular-devkit/core": "~15.0.0",
     "@nguniversal/common": "0.0.0-PLACEHOLDER",
     "browser-sync": "^2.27.10",
     "express": "^4.18.2",
@@ -37,7 +37,7 @@
     "http-proxy-middleware": "^2.0.6",
     "ora": "^5.1.0",
     "piscina": "~3.2.0",
-    "rxjs": "RXJS_VERSION",
+    "rxjs": "^6.5.5",
     "tree-kill": "^1.2.2"
   }
 }

--- a/modules/common/package.json
+++ b/modules/common/package.json
@@ -17,11 +17,11 @@
   "dependencies": {
     "critters": "0.0.16",
     "jsdom": "21.0.0",
-    "tslib": "TSLIB_VERSION"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/common": "NG_VERSION",
-    "@angular/core": "NG_VERSION"
+    "@angular/common": "^15.0.0",
+    "@angular/core": "^15.0.0"
   },
   "schematics": "./schematics/collection.json",
   "ng-update": {

--- a/modules/express-engine/package.json
+++ b/modules/express-engine/package.json
@@ -12,14 +12,14 @@
     "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
   },
   "peerDependencies": {
-    "@angular/common": "NG_VERSION",
-    "@angular/core": "NG_VERSION",
-    "@angular/platform-server": "NG_VERSION",
+    "@angular/common": "^15.0.0",
+    "@angular/core": "^15.0.0",
+    "@angular/platform-server": "^15.0.0",
     "express": "EXPRESS_VERSION"
   },
   "dependencies": {
     "@nguniversal/common": "0.0.0-PLACEHOLDER",
-    "tslib": "TSLIB_VERSION"
+    "tslib": "^2.3.0"
   },
   "schematics": "./schematics/collection.json",
   "ng-update": {

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -46,14 +46,8 @@ def ts_library(
         **kwargs
     )
 
-NG_VERSION = "^15.0.0-next.0"
-RXJS_VERSION = "^6.5.5"
 EXPRESS_VERSION = "^4.15.2"
 EXPRESS_TYPES_VERSION = "^4.17.0"
-DEVKIT_CORE_VERSION = "^15.0.0-next.0"
-DEVKIT_ARCHITECT_VERSION = "^0.1500.0-next.0"
-DEVKIT_BUILD_ANGULAR_VERSION = "^15.0.0-next.0"
-TSLIB_VERSION = "^2.3.0"
 
 NGUNIVERSAL_SCOPED_PACKAGES = ["@nguniversal/%s" % p for p in [
     "builders",
@@ -67,12 +61,6 @@ PKG_GROUP_REPLACEMENTS = {
     ]""" % ",\n      ".join(["\"%s\"" % s for s in NGUNIVERSAL_SCOPED_PACKAGES]),
     "EXPRESS_VERSION": EXPRESS_VERSION,
     "EXPRESS_TYPES_VERSION": EXPRESS_TYPES_VERSION,
-    "NG_VERSION": NG_VERSION,
-    "RXJS_VERSION": RXJS_VERSION,
-    "DEVKIT_CORE_VERSION": DEVKIT_CORE_VERSION,
-    "DEVKIT_ARCHITECT_VERSION": DEVKIT_ARCHITECT_VERSION,
-    "DEVKIT_BUILD_ANGULAR_VERSION": DEVKIT_BUILD_ANGULAR_VERSION,
-    "TSLIB_VERSION": TSLIB_VERSION,
 }
 
 def ng_module(name, package_name, module_name = None, tsconfig = None, testonly = False, deps = [], **kwargs):


### PR DESCRIPTION

This is so that version updates are managed by renovate bot.