### PR TITLE
Update next branch to reflect new release-train "v15.2.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+<a name="15.1.0-rc.0"></a>
+
+# 15.1.0-rc.0 (2023-01-12)
+
+### @nguniversal/builders
+
+| Commit                                                                                           | Type | Description                                      |
+| ------------------------------------------------------------------------------------------------ | ---- | ------------------------------------------------ |
+| [98d7837b](https://github.com/angular/universal/commit/98d7837bf67c047cb8358ba6394b6180453bc420) | fix  | disable bundle budgets when using the dev-server |
+
+## Special Thanks
+
+Alan Agius, Charles Lyding, Doug Parker, Mark Pieszak and Paul Gschwendtner
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="14.2.3"></a>
 
 # 14.2.3 (2022-11-23)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nguniversal",
   "main": "index.js",
-  "version": "15.1.0-next.0",
+  "version": "15.2.0-next.0",
   "private": true,
   "description": "Universal (isomorphic) JavaScript support for Angular",
   "homepage": "https://github.com/angular/universal",


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v15.1.0-rc.0 into the main branch so that the changelog is up to date.