### PR TITLE
ci: disable Renovate updates for `@angular/bazel`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node"],
+  "ignoreDeps": ["@types/node", "@angular/bazel"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
This package contains changes which are no longer compatible with this repo and also require upstream changes.

See: https://github.com/angular/angular/pull/48521