### PR TITLE
feat(@nguniversal/builders): add `--verbose` option to SSR Dev Server

### DIFF
--- a/modules/builders/src/ssr-dev-server/index.ts
+++ b/modules/builders/src/ssr-dev-server/index.ts
@@ -59,6 +59,7 @@ export function execute(
     serviceWorker: false,
     watch: true,
     progress: options.progress,
+    verbose: options.verbose,
     // Disable bundle budgets are these are not meant to be used with a dev-server as this will add extra JavaScript for live-reloading.
     budgets: [],
   });
@@ -66,6 +67,7 @@ export function execute(
   const serverTargetRun = context.scheduleTarget(serverTarget, {
     watch: true,
     progress: options.progress,
+    verbose: options.verbose,
   });
 
   const bsInstance = browserSync.create();
@@ -239,7 +241,7 @@ async function initBrowserSync(
     server: false,
     notify: false,
     ghostMode: false,
-    logLevel: 'silent',
+    logLevel: options.verbose ? 'debug' : 'silent',
     open,
     https: getSslConfig(context.workspaceRoot, options),
   };

--- a/modules/builders/src/ssr-dev-server/schema.json
+++ b/modules/builders/src/ssr-dev-server/schema.json
@@ -59,6 +59,10 @@
     "proxyConfig": {
       "type": "string",
       "description": "Proxy configuration file."
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Adds more details to output logging."
     }
   },
   "additionalProperties": false,

--- a/modules/builders/src/ssr-dev-server/schema.ts
+++ b/modules/builders/src/ssr-dev-server/schema.ts
@@ -45,4 +45,7 @@ export interface Schema {
 
   /** Proxy configuration file */
   proxyConfig?: string;
+
+  /** Adds more details to output logging */
+  verbose: boolean;
 }


### PR DESCRIPTION
This change adds the `--verbose` option to the SSR dev server.

closes #2909