### PR TITLE
Update next branch to reflect new release-train "v15.3.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+<a name="15.2.0-rc.0"></a>
+
+# 15.2.0-rc.0 (2023-02-23)
+
+### @nguniversal/common
+
+| Commit                                                                                           | Type | Description                                        |
+| ------------------------------------------------------------------------------------------------ | ---- | -------------------------------------------------- |
+| [78dc17db](https://github.com/angular/universal/commit/78dc17dbc9a1ae844737c029deaef10c1d77ebba) | feat | add removal notice for Clover APIs                 |
+| [93c8a38d](https://github.com/angular/universal/commit/93c8a38debbc2763d69d4557371750a0e96c1b6a) | fix  | avoid invalidating cache when using a post request |
+
+### @nguniversal/builders
+
+| Commit                                                                                           | Type | Description                              |
+| ------------------------------------------------------------------------------------------------ | ---- | ---------------------------------------- |
+| [0e7dd9ac](https://github.com/angular/universal/commit/0e7dd9ac2e05c76af3828cacc7631863bff71c6c) | feat | add `--verbose` option to SSR Dev Server |
+
+## Special Thanks
+
+Alan Agius
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="15.1.0"></a>
 
 # 15.1.0 (2023-01-12)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nguniversal",
   "main": "index.js",
-  "version": "15.2.0-next.0",
+  "version": "15.3.0-next.0",
   "private": true,
   "description": "Universal (isomorphic) JavaScript support for Angular",
   "homepage": "https://github.com/angular/universal",


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v15.2.0-rc.0 into the main branch so that the changelog is up to date.