### PR TITLE
refactor(@nguniversal/common): remove Node.js v14 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@
 # **NOTE 1**: Pin to exact images using an ID (SHA). See https://circleci.com/docs/2.0/circleci-images/#using-a-docker-image-id-to-pin-an-image-to-a-fixed-version.
 #             (Using the tag in not necessary when pinning by ID, but include it anyway for documentation purposes.)
 # **NOTE 2**: If you change the version of the docker images, also change the `cache_key` suffix.
-var_1: &docker_image cimg/node:14.20
-var_2: &cache_key angular_universal-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-node-14.20
+var_1: &docker_image cimg/node:16.13
+var_2: &cache_key angular_universal-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-node-16.13
 
 # Workspace initially persisted by the `setup` job.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,7 +26,7 @@ load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
 nodejs_register_toolchains(
     name = "nodejs",
-    node_version = "14.20.0",
+    node_version = "16.13.1",
 )
 
 load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")

--- a/modules/builders/package.json
+++ b/modules/builders/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/angular/universal#readme",
   "license": "MIT",
   "engines": {
-    "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
+    "node": "^16.13.0 || >=18.10.0"
   },
   "keywords": [
     "ssr",

--- a/modules/common/package.json
+++ b/modules/common/package.json
@@ -12,7 +12,7 @@
     "default": "./tools/bundles/index.js"
   },
   "engines": {
-    "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
+    "node": "^16.13.0 || >=18.10.0"
   },
   "dependencies": {
     "critters": "0.0.16",

--- a/modules/express-engine/package.json
+++ b/modules/express-engine/package.json
@@ -9,7 +9,7 @@
     "universal"
   ],
   "engines": {
-    "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
+    "node": "^16.13.0 || >=18.10.0"
   },
   "peerDependencies": {
     "@angular/common": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "engine-strict": true
   },
   "engines": {
-    "node": "^14.20.0 || ^16.13.0 || ^18.10.0",
+    "node": "^16.13.0 || ^18.10.0",
     "yarn": ">=1.21.1 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },


### PR DESCRIPTION
BREAKING CHANGE: Node.js v14 support has been removed

Node.js v14 is planned to be End-of-Life on 2023-04-30. Angular will stop supporting Node.js v14 in Angular v16. Angular v16 will continue to officially support Node.js versions v16 and v18.