### PR TITLE
fix(@nguniversal/common): update TransferHttpResponse requiring body and headers

### DIFF
--- a/modules/common/clover/src/transfer-http-cache/transfer-http-cache.interceptor.ts
+++ b/modules/common/clover/src/transfer-http-cache/transfer-http-cache.interceptor.ts
@@ -23,8 +23,8 @@ import { filter, take, tap } from 'rxjs/operators';
 type ResponseType = HttpRequest<unknown>['responseType'];
 
 interface TransferHttpResponse {
-  body?: any | null;
-  headers?: Record<string, string[]>;
+  body: any;
+  headers: Record<string, string[]>;
   status?: number;
   statusText?: string;
   url?: string;
@@ -75,10 +75,10 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
 
     if (this.transferState.hasKey(storeKey)) {
       // Request found in cache. Respond using it.
-      const response = this.transferState.get(storeKey, {});
-      let body: ArrayBuffer | Blob | string | undefined = response.body;
+      const response = this.transferState.get(storeKey, null);
+      let body: ArrayBuffer | Blob | string | undefined = response?.body;
 
-      switch (response.responseType) {
+      switch (response?.responseType) {
         case 'arraybuffer':
           {
             // If we're in Node...
@@ -103,10 +103,10 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
       return of(
         new HttpResponse<any>({
           body,
-          headers: new HttpHeaders(response.headers),
-          status: response.status,
-          statusText: response.statusText,
-          url: response.url,
+          headers: new HttpHeaders(response?.headers),
+          status: response?.status,
+          statusText: response?.statusText,
+          url: response?.url,
         }),
       );
     }

--- a/modules/common/src/transfer_http.ts
+++ b/modules/common/src/transfer_http.ts
@@ -23,9 +23,9 @@ import { defaultIfEmpty, first, tap } from 'rxjs/operators';
 
 type ResponseType = HttpRequest<unknown>['responseType'];
 
-export interface TransferHttpResponse {
-  body?: any | null;
-  headers?: Record<string, string[]>;
+interface TransferHttpResponse {
+  body: any;
+  headers: Record<string, string[]>;
   status?: number;
   statusText?: string;
   url?: string;
@@ -90,10 +90,10 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
 
     if (this.transferState.hasKey(storeKey)) {
       // Request found in cache. Respond using it.
-      const response = this.transferState.get(storeKey, {});
-      let body: ArrayBuffer | Blob | string | undefined = response.body;
+      const response = this.transferState.get(storeKey, null);
+      let body: ArrayBuffer | Blob | string | undefined = response?.body;
 
-      switch (response.responseType) {
+      switch (response?.responseType) {
         case 'arraybuffer':
           body = new TextEncoder().encode(response.body).buffer;
           break;
@@ -105,10 +105,10 @@ export class TransferHttpCacheInterceptor implements HttpInterceptor {
       return observableOf(
         new HttpResponse<any>({
           body,
-          headers: new HttpHeaders(response.headers),
-          status: response.status,
-          statusText: response.statusText,
-          url: response.url,
+          headers: new HttpHeaders(response?.headers),
+          status: response?.status,
+          statusText: response?.statusText,
+          url: response?.url,
         }),
       );
     } else {


### PR DESCRIPTION
As per the discussion and @alan-agius4's point regarding the `TransferHttpResponse` shape under https://github.com/angular/angular/pull/49509. I suggest to align the status of optional and required keys of `TransferHttpResponse` interface of universal's interceptor to meet Angular's `packages/common/http/src/transfer_cache.ts `counterpart.