### PR TITLE
refactor(@nguniversal/common): remove usage of `BrowserTransferStateModule`

### DIFF
--- a/docs/transfer-http.md
+++ b/docs/transfer-http.md
@@ -7,7 +7,7 @@ side.
 When the module is installed in the application `NgModule`, it will intercept `HttpClient` requests
 on the server and store the response in the `TransferState` key-value store. This is transferred to the client, which then uses it to respond to the same `HttpClient` requests on the client.
 
-Any requests other than GET will prevent any further requests. You may alternatively use `BrowserTransferStateModule` to write your own behaviour for caching information.
+Any requests other than GET will prevent any further requests.
 
 ### Usage
 

--- a/modules/common/clover/src/transfer-http-cache/transfer-http-cache.module.ts
+++ b/modules/common/clover/src/transfer-http-cache/transfer-http-cache.module.ts
@@ -8,7 +8,6 @@
 
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { BrowserTransferStateModule } from '@angular/platform-browser';
 import { TransferHttpCacheInterceptor } from './transfer-http-cache.interceptor';
 
 /**
@@ -16,7 +15,6 @@ import { TransferHttpCacheInterceptor } from './transfer-http-cache.interceptor'
  * @experimental
  */
 @NgModule({
-  imports: [BrowserTransferStateModule],
   providers: [
     TransferHttpCacheInterceptor,
     { provide: HTTP_INTERCEPTORS, useExisting: TransferHttpCacheInterceptor, multi: true },


### PR DESCRIPTION


This is no longer needed