### PR TITLE
fix(@nguniversal/builders): add support to serve service workers

### DIFF
--- a/modules/builders/src/ssr-dev-server/index.spec.ts
+++ b/modules/builders/src/ssr-dev-server/index.spec.ts
@@ -106,6 +106,35 @@ describe('Serve SSR Builder', () => {
     expect(await response.text()).toContain('<title>App</title>');
   });
 
+  it('works with service-worker', async () => {
+    const manifest = {
+      index: '/index.html',
+      assetGroups: [
+        {
+          name: 'app',
+          installMode: 'prefetch',
+          resources: {
+            files: ['/index.html'],
+          },
+        },
+      ],
+    };
+
+    host.writeMultipleFiles({
+      'ngsw-config.json': JSON.stringify(manifest),
+    });
+
+    const run = await architect.scheduleTarget(target, {
+      port: 7003,
+      browserTarget: 'app:build:sw',
+    });
+    runs.push(run);
+    const output = await run.result;
+    expect(output.success).toBe(true);
+    const response = await fetch('http://localhost:7003/ngsw.json');
+    expect(await response?.text()).toContain('installMode');
+  });
+
   // todo: alan-agius4: Investigate why this tests passed locally but fails in CI.
   // this is currenty disabled but still useful locally
   xit('works with rebuilds with fetch', async () => {

--- a/modules/builders/src/ssr-dev-server/index.ts
+++ b/modules/builders/src/ssr-dev-server/index.ts
@@ -56,7 +56,6 @@ export function execute(
   const getBaseUrl = (bs: browserSync.BrowserSyncInstance) =>
     `${bs.getOption('scheme')}://${bs.getOption('host')}:${bs.getOption('port')}`;
   const browserTargetRun = context.scheduleTarget(browserTarget, {
-    serviceWorker: false,
     watch: true,
     progress: options.progress,
     verbose: options.verbose,


### PR DESCRIPTION
Previously, for legacy reasons service workers were not served when using the `ssr-dev-server` builders. This commit enabled serving of service workers as now service workers can be served without valid SSL when served using localhost.