### PR TITLE
fix(@nguniversal/express-engine): export default bootstrap in server template for standalone apps

### DIFF
--- a/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
+++ b/modules/express-engine/schematics/install/files/__serverFileName@stripTsExtension__.ts
@@ -56,4 +56,4 @@ if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
   run();
 }
 
-export * from './src/<%= stripTsExtension(main) %>';
+<% if (isStandalone) { %>export default bootstrap;<% } else { %>export * from './src/<%= stripTsExtension(main) %>';<% } %>


### PR DESCRIPTION
Without explicitly exporting the `bootstrap` as the default export from the `server.ts`, prerendering fails with the following message:

```
✖ Prerendering routes to /angular-universal-standalone/dist/angular-universal-standalone/browser failed.
Neither an AppServerModule nor a bootstrapping function was exported from: /angular-universal-standalone/dist/angular-universal-standalone/server/main.js.
```

Example repo is here with the fix https://github.com/brandonroberts/angular-v16-universal-standalone