### PR TITLE
fix(@nguniversal/common): correctly handle multiple lazy CSS files

### DIFF
--- a/integration/express-engine-ivy/angular.json
+++ b/integration/express-engine-ivy/angular.json
@@ -48,7 +48,14 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.css"],
+            "styles": [
+              "src/styles.css",
+              {
+                "input": "src/styles-extra.css",
+                "inject": true,
+                "bundleName": "extra"
+              }
+            ],
             "scripts": []
           },
           "configurations": {

--- a/integration/express-engine-ivy/e2e/src/app.e2e-spec.ts
+++ b/integration/express-engine-ivy/e2e/src/app.e2e-spec.ts
@@ -61,8 +61,12 @@ describe('Hello world E2E Tests', () => {
     await browser.driver.get(browser.baseUrl);
 
     // Test the contents from the server.
-    const styleTag = browser.driver.findElement(by.css('link[rel="stylesheet"]'));
-    expect(styleTag.getAttribute('media')).toMatch('all');
+    const linkTags = await browser.driver.findElements(by.css('link[rel="stylesheet"]'));
+    expect(linkTags.length).toBe(2);
+
+    for (const linkTag of linkTags) {
+      expect(linkTag.getAttribute('media')).toMatch('all');
+    }
 
     // Make sure there were no client side errors.
     verifyNoBrowserErrors();

--- a/integration/express-engine-ivy/src/styles-extra.css
+++ b/integration/express-engine-ivy/src/styles-extra.css
@@ -1,0 +1,4 @@
+/* You can add global styles to this file, and also import other style files */
+.foo {
+  background-color: blue;
+}

--- a/modules/common/engine/src/engine.ts
+++ b/modules/common/engine/src/engine.ts
@@ -102,7 +102,7 @@ export class CommonEngine {
           document: inlineCriticalCss
             ? // Workaround for https://github.com/GoogleChromeLabs/critters/issues/64
               doc.replace(
-                / media="print" onload="this\.media='.+'"(?: ngCspMedia=".+")?><noscript><link .+?><\/noscript>/g,
+                / media="print" onload="this\.media='.+?'"(?: ngCspMedia=".+")?><noscript><link .+?><\/noscript>/g,
                 '>',
               )
             : doc,


### PR DESCRIPTION
This commit fixes an issue with the regexp that caused incorrect output.

Closes #3128