### PR TITLE
refactor: deprecate transfer http cache

### DIFF
--- a/modules/common/src/state-transfer-initializer/README.md
+++ b/modules/common/src/state-transfer-initializer/README.md
@@ -1,5 +1,7 @@
 # State Transfer Initializer
 
+## Deprecated Use [`provideClientHydration`](https://angular.io/api/platform-browser/provideClientHydration) instead which caches HTTP requests by default.
+
 Delays the app bootstrap process to ensure that the DOM content is loaded before state transfer initilization
 
 Simply import the module into your project and you will no longer need to wrap your component bootstrap function in an `DOMContentLoaded` callback

--- a/modules/common/src/state-transfer-initializer/module.ts
+++ b/modules/common/src/state-transfer-initializer/module.ts
@@ -9,6 +9,10 @@
 import { DOCUMENT } from '@angular/common';
 import { APP_INITIALIZER, NgModule } from '@angular/core';
 
+/**
+ * @deprecated Use `provideClientHydration` instead which caches HTTP requests by default.
+ * @see https://angular.io/api/platform-browser/provideClientHydration
+ */
 export function domContentLoadedFactory(doc: Document): () => Promise<void> {
   return () =>
     new Promise((resolve, _reject) => {
@@ -27,6 +31,10 @@ export function domContentLoadedFactory(doc: Document): () => Promise<void> {
     });
 }
 
+/**
+ * @deprecated Use `provideClientHydration` instead which caches HTTP requests by default.
+ * @see https://angular.io/api/platform-browser/provideClientHydration
+ */
 @NgModule({
   providers: [
     {

--- a/modules/common/src/transfer_http.ts
+++ b/modules/common/src/transfer_http.ts
@@ -50,6 +50,10 @@ function getHeadersMap(headers: HttpHeaders): Record<string, string[]> {
   return headersMap;
 }
 
+/**
+ * @deprecated Use `provideClientHydration` instead which caches HTTP requests by default.
+ * @see https://angular.io/api/platform-browser/provideClientHydration
+ */
 @Injectable()
 export class TransferHttpCacheInterceptor implements HttpInterceptor {
   private isCacheActive = true;


### PR DESCRIPTION
DEPRECATION: `StateTransferInitializerModule`, `TransferHttpCacheInterceptor` and `domContentLoadedFactory` have been deprecated in favor of `provideClientHydration`. See: https://angular.io/api/platform-browser/provideClientHydration