### PR TITLE
Update next branch to reflect new release-train "v16.3.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="16.2.0-rc.0"></a>
+
+# 16.2.0-rc.0 (2023-08-04)
+
+| Commit                                                                                           | Type     | Description            |
+| ------------------------------------------------------------------------------------------------ | -------- | ---------------------- |
+| [192326a8](https://github.com/angular/universal/commit/ccc2f52f9be47b5fb2cddd4d3f57b9a18eb1b0ca) | refactor | build: update critters |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.1.2"></a>
 
 # 16.1.2 (2023-08-04)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nguniversal",
   "main": "index.js",
-  "version": "16.2.0-next.0",
+  "version": "16.3.0-next.0",
   "private": true,
   "description": "Universal (isomorphic) JavaScript support for Angular",
   "homepage": "https://github.com/angular/universal",


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v16.2.0-rc.0 into the main branch so that the changelog is up to date.