### PR TITLE
docs: update CLI link in github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Bugs and feature requests
-    url: https://github.com/angular/angular-cli/issues/new
+    url: https://github.com/angular/angular-cli/issues/new/choose
     about: Report an issue in Angular Universal in the Angular CLI repository.
   - name: Support request
     url: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#question


### PR DESCRIPTION
Replace https://github.com/angular/angular-cli/issues/new with https://github.com/angular/angular-cli/issues/new/choose